### PR TITLE
Less specific python dependency

### DIFF
--- a/.setup-scripts/setup_env.sh
+++ b/.setup-scripts/setup_env.sh
@@ -9,7 +9,7 @@ export INTEGRATIONS_DIR_TMP=${CI_PROJECT_DIR:-"."}
 VENV_PATH=$INTEGRATIONS_DIR_TMP/venv
 
 if [ ! -d $VENV_PATH ]; then
-  virtualenv --python=python3.6 $INTEGRATIONS_DIR_TMP/venv
+  virtualenv --python=python3 $INTEGRATIONS_DIR_TMP/venv
   source $INTEGRATIONS_DIR_TMP/venv/bin/activate
   source $INTEGRATIONS_DIR_TMP/.setup-scripts/load_deps.sh
 else

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ The [StackState Agent][1] packages are equipped with all the Integrations from t
 # Development
 
 Prerequisites:
-- python 3.6
+- python 3
+- bash
 
 ## Setup
 


### PR DESCRIPTION
Binary python3.6 requirement relaxed to python3

I tried the commands on ZSH and ran into some minor issues, works fine in bash -- added that 'requirement'