### PR TITLE
Small fix for checksdev installation

### DIFF
--- a/.setup-scripts/load_deps.sh
+++ b/.setup-scripts/load_deps.sh
@@ -3,6 +3,6 @@
 set -x
 
 pip install -U pip setuptools codecov
-pip install ./stackstate_checks_dev[cli]
+pip install "./stackstate_checks_dev[cli]"
 
 set +x


### PR DESCRIPTION
I got this error under mac os using zsh:

```
 (venv) ➜  stackstate-agent-integrations git:(master) pip install ./stackstate_checks_dev[cli]
zsh: no matches found: ./stackstate_checks_dev[cli]
```
By putting quotes around the `./stackstate_checks_dev[cli]` the issue got resolved
