### PR TITLE
Fix issue in agent scaffolding with sts_testenvironment 

### DIFF
--- a/stackstate_checks_dev/stackstate_checks/dev/tooling/templates/check/{check_name}/tests/conftest.py
+++ b/stackstate_checks_dev/stackstate_checks/dev/tooling/templates/check/{check_name}/tests/conftest.py
@@ -3,8 +3,10 @@
 
 @pytest.fixture(scope='session')
 def sts_environment():
-    yield
-
+    # This conf instance is used when running `checksdev env start mycheck myenv`. 
+    # The start command places this as a `conf.yaml` in the `conf.d/mycheck/` directory.
+    # If you want to run an environment this object can not be empty. 
+    return {{ "key": "value" }}
 
 @pytest.fixture
 def instance():


### PR DESCRIPTION
Fixes an issue that made running a check after scaffolding not work. You would get an error that the check could not be found. Apparently the test environment needed an object with something (anything) in it.