### PR TITLE
STAC-9771: Expose OpenMetrics agent integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -145,6 +145,14 @@ test_mysql:
   tags:
     - sts-aws
 
+test_openmetrics:
+  <<: *linux_test
+  variables:
+    CHECK: "openmetrics"
+    PYTHON3: "true"
+    DOCKER_HOST: tcp://docker:2375/
+    DOCKER_DRIVER: overlay2
+
 test_postgres:
   <<: *linux_test
   variables:

--- a/openmetrics/CHANGELOG.md
+++ b/openmetrics/CHANGELOG.md
@@ -1,0 +1,2 @@
+# CHANGELOG - Openmetrics
+

--- a/openmetrics/MANIFEST.in
+++ b/openmetrics/MANIFEST.in
@@ -1,0 +1,10 @@
+graft stackstate_checks
+graft tests
+
+include MANIFEST.in
+include README.md
+include requirements.in
+include requirements-dev.txt
+include manifest.json
+
+global-exclude *.py[cod] __pycache__

--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -25,7 +25,7 @@ need to install anything else on your server.
 
 ### Metrics
 
-All metrics collected by the OpenMetrics check are forwarded to Datadog as custom metrics.
+All metrics collected by the OpenMetrics check are forwarded to StackState as custom metrics.
 
 ### Service Checks
 

--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -1,0 +1,41 @@
+# Agent Check: Openmetrics
+
+## Overview
+
+This check monitors [Openmetrics][1] through the StackState Agent.
+
+## Setup
+
+### Installation
+
+The Openmetrics check is included in the [StackState Agent][2] package, so you do not
+need to install anything else on your server.
+
+### Configuration
+
+1. Edit the `openmetrics.d/conf.yaml` file, in the `conf.d/` folder at the root of your
+   Agent's configuration directory to start collecting your openmetrics performance data.
+   See the [sample openmetrics.d/conf.yaml][2] for all available configuration options.
+
+2. Restart the Agent
+
+## Data Collected
+
+### Metrics
+
+Openmetrics does not include any metrics.
+
+### Service Checks
+
+Openmetrics does not include any service checks.
+
+### Events
+
+Openmetrics does not include any events.
+
+### Topology
+
+Openmetrics does not include any topology.
+
+[1]: **LINK_TO_INTEGERATION_SITE**
+[2]: https://github.com/StackVista/stackstate-agent-integrations/blob/master/openmetrics/stackstate_checks/openmetrics/data/conf.yaml.example

--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-This check monitors [Openmetrics][1] through the StackState Agent.
+Extract custom metrics from any OpenMetrics endpoints.
+
+**Note:** All the metrics retrieved by this integration are considered as custom metrics.
 
 ## Setup
 
@@ -23,7 +25,7 @@ need to install anything else on your server.
 
 ### Metrics
 
-Openmetrics does not include any metrics.
+All metrics collected by the OpenMetrics check are forwarded to Datadog as custom metrics.
 
 ### Service Checks
 

--- a/openmetrics/manifest.json
+++ b/openmetrics/manifest.json
@@ -6,7 +6,7 @@
   "metric_prefix": "openmetrics.",
   "metric_to_check": "",
   "creates_events": false,
-  "short_description": "penMetrics is an open standard for exposing metric data",
+  "short_description": "OpenMetrics is an open standard for exposing metric data",
   "guid": "0e522171-f799-4694-9ddd-a143c4199a54",
   "support": "core",
   "supported_os": [

--- a/openmetrics/manifest.json
+++ b/openmetrics/manifest.json
@@ -1,6 +1,6 @@
 {
   "display_name": "OpenMetrics",
-  "maintainer": "jvanerp@stackstate.com",
+  "maintainer": "info@stackstate.com",
   "manifest_version": "1.0.0",
   "name": "openmetrics",
   "metric_prefix": "openmetrics.",
@@ -19,5 +19,5 @@
     "monitoring"
   ],
   "type": "check",
-  "is_public": false
+  "is_public": true
 }

--- a/openmetrics/manifest.json
+++ b/openmetrics/manifest.json
@@ -1,0 +1,23 @@
+{
+  "display_name": "OpenMetrics",
+  "maintainer": "jvanerp@stackstate.com",
+  "manifest_version": "1.0.0",
+  "name": "openmetrics",
+  "metric_prefix": "openmetrics.",
+  "metric_to_check": "",
+  "creates_events": false,
+  "short_description": "penMetrics is an open standard for exposing metric data",
+  "guid": "0e522171-f799-4694-9ddd-a143c4199a54",
+  "support": "core",
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "public_title": "StackState-OpenMetrics Integration",
+  "categories": [
+    "monitoring"
+  ],
+  "type": "check",
+  "is_public": false
+}

--- a/openmetrics/metadata.csv
+++ b/openmetrics/metadata.csv
@@ -1,0 +1,1 @@
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name

--- a/openmetrics/requirements-dev.txt
+++ b/openmetrics/requirements-dev.txt
@@ -1,0 +1,1 @@
+-e ../stackstate_checks_dev

--- a/openmetrics/setup.py
+++ b/openmetrics/setup.py
@@ -33,8 +33,8 @@ setup(
     url='https://github.com/StackVista/stackstate-agent-integrations',
 
     # Author details
-    author='Jeroen van Erp',
-    author_email='jvanerp@stackstate.com',
+    author='StackState',
+    author_email='info@stackstate.com',
 
     # License
     license='BSD-3-Clause',

--- a/openmetrics/setup.py
+++ b/openmetrics/setup.py
@@ -1,0 +1,62 @@
+# (C) StackState 2020
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from codecs import open  # To use a consistent encoding
+from os import path
+
+from setuptools import setup
+
+HERE = path.dirname(path.abspath(__file__))
+
+# Get version info
+ABOUT = {}
+with open(path.join(HERE, 'stackstate_checks', 'openmetrics', '__about__.py')) as f:
+    exec(f.read(), ABOUT)
+
+# Get the long description from the README file
+with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+
+CHECKS_BASE_REQ = 'stackstate-checks-base'
+
+
+setup(
+    name='stackstate-openmetrics',
+    version=ABOUT['__version__'],
+    description='The Openmetrics check',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    keywords='stackstate agent openmetrics check',
+
+    # The project's main homepage.
+    url='https://github.com/StackVista/stackstate-agent-integrations',
+
+    # Author details
+    author='Jeroen van Erp',
+    author_email='jvanerp@stackstate.com',
+
+    # License
+    license='BSD-3-Clause',
+
+    # See https://pypi.org/classifiers
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Intended Audience :: System Administrators',
+        'Topic :: System :: Monitoring',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ],
+
+    # The package we're going to ship
+    packages=['stackstate_checks.openmetrics'],
+
+    # Run-time dependencies
+    install_requires=[CHECKS_BASE_REQ],
+
+    # Extra files to ship with the wheel package
+    include_package_data=True,
+)

--- a/openmetrics/stackstate_checks/__init__.py
+++ b/openmetrics/stackstate_checks/__init__.py
@@ -1,0 +1,4 @@
+# (C) StackState 2020
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/openmetrics/stackstate_checks/openmetrics/__about__.py
+++ b/openmetrics/stackstate_checks/openmetrics/__about__.py
@@ -1,0 +1,4 @@
+# (C) StackState 2020
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+__version__ = '0.0.1'

--- a/openmetrics/stackstate_checks/openmetrics/__init__.py
+++ b/openmetrics/stackstate_checks/openmetrics/__init__.py
@@ -1,0 +1,10 @@
+# (C) StackState 2020
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from .__about__ import __version__
+from .openmetrics import OpenMetricsCheck
+
+__all__ = [
+    '__version__',
+    'OpenMetricsCheck'
+]

--- a/openmetrics/stackstate_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/stackstate_checks/openmetrics/data/conf.yaml.example
@@ -1,0 +1,117 @@
+init_config:
+
+instances:
+  ## @param prometheus_url - string -required
+  ## The URL where your application metrics are exposed by Prometheus.
+  #
+  - prometheus_url: http://service/prometheus
+
+  ## @param namespace - string - required
+  ## The namespace to be prepended to all metrics.
+  #
+    namespace: "service"
+
+  ## @param metrics - list of strings - required
+  ## List of metrics to be fetched from the prometheus endpoint, if there's a
+  ## value it'll be renamed. This list should contain at least one metric
+  #
+    metrics:
+      - processor: cpu
+      - memory: mem
+      - io
+
+  ## @param prometheus_metrics_prefix - string - optional
+  ## <PREFIX> for exposed Prometheus metrics.
+  #
+  #  prometheus_metrics_prefix: <PREFIX>_
+
+  ## @param health_service_check - boolean - optional - default: true
+  ## Send a service check reporting about the health of the prometheus endpoint
+  ## It's named <NAMESPACE>.prometheus.health
+  #
+  #  health_service_check: true
+
+  ## @param label_to_hostname - string - optional
+  ## Override the hostname with the value of one label.
+  #
+  #  label_to_hostname: <LABEL>
+
+  ## @param label_joins - custom - optional
+  ## The label join allows to target a metric and retrieve it's label via a 1:1 mapping
+  #
+  #  label_joins:
+  #    target_metric:
+  #      label_to_match: <MATCHED_LABEL>
+  #      labels_to_get:
+  #        - <EXTRA_LABEL_1>
+  #        - <EXTRA_LABEL_2>
+
+  ## @param labels_mapper - list of key:value elements - optional
+  ## The label mapper allows you to rename labels.
+  ## Format is <LABEL_TO_RENAME>: <NEW_LABEL_NAME>
+  #
+  #  labels_mapper:
+  #    flavor: origin
+
+  ## @param type_overrides - list of key:value elements - optional
+  ## Type override allows you to override a type in the prometheus the payload
+  ## or type an untyped metrics (they're ignored by default)
+  ## Supported <METRIC_TYPE> are `gauge`, `count`, `rate`
+  #
+  #  type_overrides:
+  #    <METRIC_NAME>: <METRIC_TYPE>
+
+  ## @param tags  - list of key:value element - optional
+  ## List of tags to attach to every metric, event and service check emitted by this integration.
+  ##
+  ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+  #
+  #  tags:
+  #    - <KEY_1>:<VALUE_1>
+  #    - <KEY_2>:<VALUE_2>
+
+  ## @param send_histograms_buckets - boolean - optional - default: true
+  ## Set send_histograms_buckets to true to send the histograms bucket.
+  #
+  #  send_histograms_buckets: true
+
+  ## @param send_monotonic_counter - boolean - optional - default: true
+  ## Set send_monotonic_counter to true to send counters as monotonic counter.
+  #
+  #  send_monotonic_counter: true
+
+  ## @param exclude_labels - list of strings - optional
+  ## List of label to be excluded
+  #
+  #  exclude_labels:
+  #    - timestamp
+
+  ## @param prometheus_timeout - integer - optional - default: 10
+  ## Set a timeout for the prometheus query.
+  #
+  #  prometheus_timeout: 10
+
+  ## @param ssl_cert - string - optional
+  ## If your prometheus endpoint is secured, enter the path to the certificate and
+  ## you should specify the private key in ssl_private_key parameter
+  ## or it can be the path to a file containing both the certificate & the private key
+  #
+  #  ssl_cert: "<CERT_PATH>"
+
+  ## @param ssl_private_key - string - optional
+  ## Needed if the certificate linked in ssl_cert does not include the private key.
+  ## Note: The private key to your local certificate must be unencrypted.
+  #
+  #  ssl_private_key: "<KEY_PATH>"
+
+  ## @param ssl_ca_cert - string - optional
+  ## The path to the trusted CA used for generating custom certificates.
+  #
+  #  ssl_ca_cert: "<CA_CERT_PATH>"
+
+  ## @param extra_headers - list of key:value elements - optional
+  ## A list of additional HTTP headers to send in queries to the openmetrics endpoint.
+  ## Can be combined with autodiscovery template variables. Eg: "Authorization: Bearer %%env_TOKEN%%".
+  #
+  #  extra_headers:
+  #    <HEADER_NAME>: <HEADER_VALUE>

--- a/openmetrics/stackstate_checks/openmetrics/openmetrics.py
+++ b/openmetrics/stackstate_checks/openmetrics/openmetrics.py
@@ -1,0 +1,8 @@
+# (C) StackState 2020
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from stackstate_checks.base.checks.openmetrics import OpenMetricsBaseCheck
+
+
+class OpenMetricsCheck(OpenMetricsBaseCheck):
+    pass

--- a/openmetrics/tests/__init__.py
+++ b/openmetrics/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) StackState 2020
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/openmetrics/tests/test_openmetrics.py
+++ b/openmetrics/tests/test_openmetrics.py
@@ -205,7 +205,7 @@ def test_openmetrics_mixed_instance(aggregator):
     aggregator.assert_metric(
         CHECK_NAME + '.renamed.metric1',
         hostname='host1',
-        tags=['node:host1', 'flavor:test', 'matched_label:foobar', 'timestamp:123', 'extra:foo'],
+        tags=['node:host1', 'flavor:test', 'matched_label:foobar', 'extra:foo'],
         metric_type=aggregator.GAUGE
     )
     aggregator.assert_metric(

--- a/openmetrics/tests/test_openmetrics.py
+++ b/openmetrics/tests/test_openmetrics.py
@@ -1,0 +1,217 @@
+# (C) StackState 2020
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from stackstate_checks.openmetrics import OpenMetricsCheck
+import pytest
+import mock
+from prometheus_client import generate_latest, CollectorRegistry, Gauge, Counter
+
+CHECK_NAME = 'openmetrics'
+NAMESPACE = 'openmetrics'
+
+instance = {
+    'prometheus_url': 'http://localhost:10249/metrics',
+    'namespace': 'openmetrics',
+    'metrics': [
+        {'metric1': 'renamed.metric1'},
+        'metric2',
+        'counter1'
+    ],
+    'send_histograms_buckets': True,
+    'send_monotonic_counter': True
+}
+
+
+@pytest.fixture(scope='module', autouse=True)
+def poll_mock():
+    registry = CollectorRegistry()
+    g1 = Gauge('metric1', 'processor usage', ['matched_label', 'node', 'flavor'], registry=registry)
+    g1.labels(matched_label='foobar', node='host1', flavor='test').set(99.9)
+    g2 = Gauge('metric2', 'memory usage', ['matched_label', 'node', 'timestamp'], registry=registry)
+    g2.labels(matched_label='foobar', node='host2', timestamp='123').set(12.2)
+    c1 = Counter('counter1', 'hits', ['node'], registry=registry)
+    c1.labels(node='host2').inc(42)
+    g3 = Gauge('metric3', 'memory usage', ['matched_label', 'node', 'timestamp'], registry=registry)
+    g3.labels(matched_label='foobar', node='host2', timestamp='456').set(float('inf'))
+
+    with mock.patch(
+        'requests.get',
+        return_value=mock.MagicMock(
+            status_code=200,
+            iter_lines=lambda **kwargs: generate_latest(registry).decode().split('\n'),
+            headers={'Content-Type': 'text/plain'}
+        )
+    ):
+        yield
+
+
+def test_openmetrics_check(aggregator):
+    c = OpenMetricsCheck('openmetrics', None, {}, [instance])
+    c.check(instance)
+    aggregator.assert_metric(
+        CHECK_NAME + '.renamed.metric1',
+        tags=['node:host1', 'flavor:test', 'matched_label:foobar'],
+        metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_metric(
+        CHECK_NAME + '.metric2',
+        tags=['timestamp:123', 'node:host2', 'matched_label:foobar'],
+        metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_metric(
+        CHECK_NAME + '.counter1',
+        tags=['node:host2'],
+        metric_type=aggregator.MONOTONIC_COUNT
+    )
+    aggregator.assert_all_metrics_covered()
+
+
+def test_openmetrics_check_counter_gauge(aggregator):
+    instance['send_monotonic_counter'] = False
+    c = OpenMetricsCheck('openmetrics', None, {}, [instance])
+    c.check(instance)
+    aggregator.assert_metric(
+        CHECK_NAME + '.renamed.metric1',
+        tags=['node:host1', 'flavor:test', 'matched_label:foobar'],
+        metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_metric(
+        CHECK_NAME + '.metric2',
+        tags=['timestamp:123', 'node:host2', 'matched_label:foobar'],
+        metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_metric(
+        CHECK_NAME + '.counter1',
+        tags=['node:host2'],
+        metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_all_metrics_covered()
+
+
+def test_invalid_metric(aggregator):
+    """
+    Testing that invalid values of metrics are discarded
+    """
+    bad_metric_instance = {
+        'prometheus_url': 'http://localhost:10249/metrics',
+        'namespace': 'openmetrics',
+        'metrics': [
+            {'metric1': 'renamed.metric1'},
+            'metric2',
+            'metric3'
+        ],
+        'send_histograms_buckets': True
+    }
+    c = OpenMetricsCheck('openmetrics', None, {}, [bad_metric_instance])
+    c.check(bad_metric_instance)
+    assert aggregator.metrics('metric3') == []
+
+
+def test_openmetrics_wildcard(aggregator):
+    instance_wildcard = {
+        'prometheus_url': 'http://localhost:10249/metrics',
+        'namespace': 'openmetrics',
+        'metrics': ['metric*'],
+    }
+
+    c = OpenMetricsCheck('openmetrics', None, {}, [instance_wildcard])
+    c.check(instance)
+    aggregator.assert_metric(
+        CHECK_NAME + '.metric1',
+        tags=['node:host1', 'flavor:test', 'matched_label:foobar'],
+        metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_metric(
+        CHECK_NAME + '.metric2',
+        tags=['timestamp:123', 'node:host2', 'matched_label:foobar'],
+        metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_all_metrics_covered()
+
+
+def test_openmetrics_default_instance(aggregator):
+    """
+    Testing openmetrics with default instance
+    """
+
+    c = OpenMetricsCheck(CHECK_NAME, None, {}, [], default_instances={
+        'openmetrics': {
+            'prometheus_url': 'http://localhost:10249/metrics',
+            'namespace': 'openmetrics',
+            'metrics': [
+                {'metric1': 'renamed.metric1'},
+                'metric2'
+            ]
+        }},
+        default_namespace='openmetrics')
+    c.check({
+        'prometheus_url': 'http://custom:1337/metrics',
+    })
+    aggregator.assert_metric(
+        CHECK_NAME + '.renamed.metric1',
+        tags=['node:host1', 'flavor:test', 'matched_label:foobar'],
+        metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_metric(
+        CHECK_NAME + '.metric2',
+        tags=['timestamp:123', 'node:host2', 'matched_label:foobar'],
+        metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_all_metrics_covered()
+
+
+def test_openmetrics_mixed_instance(aggregator):
+    c = OpenMetricsCheck(CHECK_NAME, None, {}, [], default_instances={
+        'foobar': {
+            'prometheus_url': 'http://localhost:10249/metrics',
+            'namespace': 'foobar',
+            'metrics': [
+                'metric3',
+                'metric4'
+            ]
+        }, 'openmetrics': {
+            'prometheus_url': 'http://localhost:10249/metrics',
+            'namespace': 'openmetrics',
+            'metrics': [
+                'metric2'
+            ],
+            'label_joins': {
+                'metric2': {
+                    'label_to_match': 'matched_label',
+                    'labels_to_get': ['timestamp']
+                },
+            },
+            'tags': ['extra:bar']
+        }},
+        default_namespace='openmetrics')
+    # run the check twice for label joins
+    for _ in range(2):
+        c.check({
+            'prometheus_url': 'http://custom:1337/metrics',
+            'namespace': 'openmetrics',
+            'metrics': [
+                {'metric1': 'renamed.metric1'}
+            ],
+            'label_joins': {
+                'renamed.metric1': {
+                    'label_to_match': 'matched_label',
+                    'labels_to_get': ['flavor']
+                },
+            },
+            'label_to_hostname': 'node',
+            'tags': ['extra:foo']
+        })
+
+    aggregator.assert_metric(
+        CHECK_NAME + '.renamed.metric1',
+        hostname='host1',
+        tags=['node:host1', 'flavor:test', 'matched_label:foobar', 'timestamp:123', 'extra:foo'],
+        metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_metric(
+        CHECK_NAME + '.metric2',
+        hostname='host2',
+        tags=['timestamp:123', 'node:host2', 'matched_label:foobar', 'extra:foo'],
+        metric_type=aggregator.GAUGE
+    )
+    aggregator.assert_all_metrics_covered()

--- a/openmetrics/tox.ini
+++ b/openmetrics/tox.ini
@@ -1,0 +1,29 @@
+[tox]
+minversion = 2.0
+skip_missing_interpreters = true
+basepython = py27
+envlist =
+    {py27,py36}-openmetrics
+    flake8
+
+[testenv]
+usedevelop = true
+platform = linux|darwin|win32
+deps =
+    -e../stackstate_checks_base[deps]
+    -rrequirements-dev.txt
+passenv =
+    DOCKER*
+    COMPOSE*
+commands =
+    pip install -r requirements.in
+    pytest -v
+
+[testenv:flake8]
+skip_install = true
+deps = flake8
+commands = flake8 .
+
+[flake8]
+exclude = .eggs,.tox,build
+max-line-length = 120


### PR DESCRIPTION
### Step 1: Link to Jira issue
STAC-9771

### Step 2: Description of changes
Adds the OpenMetrics integration, which exposes the BaseOpenMetricsIntegration.

### Step 3: Did you add / update tests for your changes in the right area?
- [ ] Unit/Component test
- [ ] Integration test	


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: