### PR TITLE
STAC-11469 remove yaml safe load from vsphere

### DIFF
--- a/vsphere/stackstate_checks/vsphere/vsphere.py
+++ b/vsphere/stackstate_checks/vsphere/vsphere.py
@@ -1321,13 +1321,12 @@ class VSphereCheck(AgentCheck):
         }
 
         # sanitize each resources to convert unicode into string types
-        vms = yaml.safe_load(json.dumps(self._vsphere_vms(content, domain, regexes)))
-        hosts = yaml.safe_load(json.dumps(self._vsphere_hosts(content, domain, regexes)))
-        datacenters = yaml.safe_load(json.dumps(self._vsphere_datacenters(content, domain)))
-        datastores = yaml.safe_load(json.dumps(self._vsphere_datastores(content, domain, regexes)))
-        clustercomputeresources = yaml.safe_load(json.dumps(self._vsphere_clustercomputeresources(content, domain,
-                                                                                                  regexes)))
-        computeresource = yaml.safe_load(json.dumps(self._vsphere_computeresources(content, domain, regexes)))
+        vms = self._fix_encoding(self._vsphere_vms(content, domain, regexes))
+        hosts = self._fix_encoding(self._vsphere_hosts(content, domain, regexes))
+        datacenters = self._fix_encoding(self._vsphere_datacenters(content, domain))
+        datastores = self._fix_encoding(self._vsphere_datastores(content, domain, regexes))
+        clustercomputeresources = self._fix_encoding(self._vsphere_clustercomputeresources(content, domain, regexes))
+        computeresource = self._fix_encoding(self._vsphere_computeresources(content, domain, regexes))
 
         # close the session after the processing of all Tags from the new Rest Client
         if self.session:

--- a/vsphere/stackstate_checks/vsphere/vsphere.py
+++ b/vsphere/stackstate_checks/vsphere/vsphere.py
@@ -1319,12 +1319,12 @@ class VSphereCheck(AgentCheck):
         }
 
         # sanitize each resources to convert unicode into string types
-        vms = self._fix_encoding(self._vsphere_vms(content, domain, regexes))
-        hosts = self._fix_encoding(self._vsphere_hosts(content, domain, regexes))
-        datacenters = self._fix_encoding(self._vsphere_datacenters(content, domain))
-        datastores = self._fix_encoding(self._vsphere_datastores(content, domain, regexes))
-        clustercomputeresources = self._fix_encoding(self._vsphere_clustercomputeresources(content, domain, regexes))
-        computeresource = self._fix_encoding(self._vsphere_computeresources(content, domain, regexes))
+        vms = self._vsphere_vms(content, domain, regexes)
+        hosts = self._vsphere_hosts(content, domain, regexes)
+        datacenters = self._vsphere_datacenters(content, domain)
+        datastores = self._vsphere_datastores(content, domain, regexes)
+        clustercomputeresources = self._vsphere_clustercomputeresources(content, domain, regexes)
+        computeresource = self._vsphere_computeresources(content, domain, regexes)
 
         # close the session after the processing of all Tags from the new Rest Client
         if self.session:

--- a/vsphere/stackstate_checks/vsphere/vsphere.py
+++ b/vsphere/stackstate_checks/vsphere/vsphere.py
@@ -15,8 +15,6 @@ import ssl
 import time
 import traceback
 import urllib3
-import json
-import yaml
 
 # 3p
 from pyVim import connect

--- a/vsphere/tests/test_vsphere.py
+++ b/vsphere/tests/test_vsphere.py
@@ -1,4 +1,5 @@
 # stdlib
+import os
 import unittest
 
 # 3p
@@ -189,7 +190,8 @@ def create_topology(topology_json):
 
         return mor
 
-    with open("./tests/data/" + topology_json, "r") as f:
+    path_to_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', topology_json)
+    with open(path_to_file, "r") as f:
         return rec_build(json.load(f))
 
 

--- a/vsphere/tox.ini
+++ b/vsphere/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py27
 envlist =
-    {py27,py36}-vsphere
+    {py27,py3}
     flake8
 
 [testenv]


### PR DESCRIPTION
### Step 1: Link to Jira issue
https://stackstate.atlassian.net/browse/STAC-11469

### Step 2: Description of changes
Removed `yaml.safe_load(json.dumps(data_from_vsphere))` as we do cleanup in `base.py` with `_fix_encoding`.

### Step 3: Did you add / update tests for your changes in the right area?
- [x] Unit/Component test
