### PR TITLE
STAC-12307 k8s 1.18 support

### DIFF
--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -11,7 +11,7 @@ kubernetes.cpu.system.total,rate,,core,,The number of cores used for system time
 kubernetes.cpu.user.total,rate,,core,,The number of cores used for user time,0,kubelet,k8s.cpu.user
 kubernetes.cpu.cfs.throttled.period,rate,,,,Number of throttled period intervals,-1,kubelet,k8s.cpu.throttled.periods
 kubernetes.cpu.cfs.throttled.second,rate,,,,Total time duration the container has been throttled,-1,kubelet,k8s.cpu.throttled.sec
-kubernetes.cpu.capacity,gauge,,core,,The number of cores in this machine,0,kubelet,k8s.cpu.capacity
+kubernetes.cpu.capacity,gauge,,core,,The number of cores in this machine (available until kubernetes v1.18),0,kubernetes,k8s.cpu.capacity
 kubernetes.cpu.usage.total,gauge,,nanocore,,The number of cores used,-1,kubelet,k8s.cpu
 kubernetes.cpu.limits,gauge,,core,,The limit of cpu cores set,0,kubelet,k8s.cpu.limits
 kubernetes.cpu.requests,gauge,,core,,The requested cpu cores,0,kubelet,k8s.cpu.requests
@@ -19,7 +19,7 @@ kubernetes.filesystem.usage,gauge,,byte,,The amount of disk used,-1,kubelet,k8s.
 kubernetes.filesystem.usage_pct,gauge,,fraction,,The percentage of disk used,-1,kubelet,k8s.disk.used_pct
 kubernetes.io.read_bytes,gauge,,byte,,The amount of bytes read from the disk,0,kubelet,k8_io_read_bytes
 kubernetes.io.write_bytes,gauge,,byte,,The amount of bytes written to the disk,0,kubelet,k8_io_write_bytes
-kubernetes.memory.capacity,gauge,,byte,,The amount of memory (in bytes) in this machine,0,kubelet,k8s.mem.capacity
+kubernetes.memory.capacity,gauge,,byte,,The amount of memory (in bytes) in this machine (available until kubernetes v1.18),0,kubernetes,k8s.mem.capacity
 kubernetes.memory.limits,gauge,,byte,,The limit of memory set,0,kubelet,k8s.mem.limits
 kubernetes.memory.sw_limit,gauge,,byte,,The limit of swap space set,0,kubelet,k8s.mem.sw_limit
 kubernetes.memory.requests,gauge,,byte,,The requested memory,0,kubelet,k8s.mem.requests

--- a/kubelet/stackstate_checks/kubelet/kubelet.py
+++ b/kubelet/stackstate_checks/kubelet/kubelet.py
@@ -185,7 +185,7 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         kubelet_conn_info = get_connection_info()
         endpoint = kubelet_conn_info.get('url')
         if endpoint is None:
-            raise CheckException("Unable to detect the kubelet URL automatically.")
+            raise CheckException("Unable to detect the kubelet URL automatically: " + kubelet_conn_info.get('err', ''))
 
         self.kube_health_url = urljoin(endpoint, KUBELET_HEALTH_PATH)
         self.node_spec_url = urljoin(endpoint, NODE_SPEC_PATH)

--- a/kubelet/stackstate_checks/kubelet/kubelet.py
+++ b/kubelet/stackstate_checks/kubelet/kubelet.py
@@ -300,13 +300,21 @@ class KubeletCheck(CadvisorPrometheusScraperMixin, OpenMetricsBaseCheck, Cadviso
         """
         Retrieve node spec from kubelet.
         """
-        node_spec = self.perform_kubelet_query(self.node_spec_url).json()
-        # TODO: report allocatable for cpu, mem, and pod capacity
-        # if we can get it locally or thru the DCA instead of the /nodes endpoint directly
-        return node_spec
+        node_resp = self.perform_kubelet_query(self.node_spec_url)
+        return node_resp
 
     def _report_node_metrics(self, instance_tags):
-        node_spec = self._retrieve_node_spec()
+        try:
+            node_resp = self._retrieve_node_spec()
+            node_resp.raise_for_status()
+        except requests.HTTPError as e:
+            if node_resp.status_code == 404:
+                # ignore HTTPError, for supporting k8s >= 1.18 in a degrated mode
+                # in 1.18 the /spec can be reactivated from the kubelet config
+                # in 1.19 the /spec will removed.
+                return
+            raise e
+        node_spec = node_resp.json()
         num_cores = node_spec.get('num_cores', 0)
         memory_capacity = node_spec.get('memory_capacity', 0)
 

--- a/kubelet/tests/test_cadvisor.py
+++ b/kubelet/tests/test_cadvisor.py
@@ -61,7 +61,9 @@ def test_kubelet_check_cadvisor(monkeypatch, aggregator, tagger):
     monkeypatch.setattr(
         check, 'retrieve_pod_list', mock.Mock(return_value=json.loads(mock_from_file('pods_list_1.2.json')))
     )
-    monkeypatch.setattr(check, '_retrieve_node_spec', mock.Mock(return_value=NODE_SPEC))
+    mock_resp = mock.Mock(status_code=200, raise_for_status=mock.Mock())
+    mock_resp.json = mock.Mock(return_value=NODE_SPEC)
+    monkeypatch.setattr(check, '_retrieve_node_spec', mock.Mock(return_value=mock_resp))
     monkeypatch.setattr(check, '_perform_kubelet_check', mock.Mock(return_value=None))
     monkeypatch.setattr(
         check, '_retrieve_cadvisor_metrics', mock.Mock(return_value=json.loads(mock_from_file('cadvisor_1.2.json')))

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 import mock
 import pytest
+import requests
 from six import iteritems
 
 from stackstate_checks.base.utils.date import UTC, parse_rfc3339
@@ -176,7 +177,8 @@ def mock_kubelet_check(monkeypatch, instances):
     """
     check = KubeletCheck('kubelet', None, {}, instances)
     monkeypatch.setattr(check, 'retrieve_pod_list', mock.Mock(return_value=json.loads(mock_from_file('pods.json'))))
-    monkeypatch.setattr(check, '_retrieve_node_spec', mock.Mock(return_value=NODE_SPEC))
+    mock_resp = mock.Mock(status_code=200, raise_for_status=mock.Mock(), json=mock.Mock(return_value=NODE_SPEC))
+    monkeypatch.setattr(check, '_retrieve_node_spec', mock.Mock(return_value=mock_resp))
     monkeypatch.setattr(check, '_perform_kubelet_check', mock.Mock(return_value=None))
     monkeypatch.setattr(check, '_compute_pod_expiration_datetime', mock.Mock(return_value=None))
 
@@ -601,7 +603,9 @@ def test_perform_kubelet_check(monkeypatch):
 
 def test_report_node_metrics(monkeypatch):
     check = KubeletCheck('kubelet', None, {}, [{}])
-    monkeypatch.setattr(check, '_retrieve_node_spec', mock.Mock(return_value={'num_cores': 4, 'memory_capacity': 512}))
+    mock_resp = mock.Mock(status_code=200, raise_for_status=mock.Mock())
+    mock_resp.json = mock.Mock(return_value={'num_cores': 4, 'memory_capacity': 512})
+    monkeypatch.setattr(check, '_retrieve_node_spec', mock.Mock(return_value=mock_resp))
     monkeypatch.setattr(check, 'gauge', mock.Mock())
     check._report_node_metrics(['foo:bar'])
     calls = [
@@ -610,6 +614,16 @@ def test_report_node_metrics(monkeypatch):
     ]
     check.gauge.assert_has_calls(calls, any_order=False)
 
+def test_report_node_metrics_kubernetes1_18(monkeypatch, aggregator):
+    check = KubeletCheck('kubelet', {}, [{}])
+    check.kubelet_credentials = KubeletCredentials({'verify_tls': 'false'})
+    check.node_spec_url = "http://localhost:10255/spec"
+
+    get = mock.MagicMock(status_code=404, iter_lines=lambda **kwargs: "Error Code")
+    get.raise_for_status.side_effect = requests.HTTPError('error')
+    with mock.patch('requests.get', return_value=get):
+        check._report_node_metrics(['foo:bar'])
+        aggregator.assert_all_metrics_covered()
 
 def test_retrieve_pod_list_success(monkeypatch):
     check = KubeletCheck('kubelet', None, {}, [{}])

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -680,3 +680,15 @@ def test_add_labels_to_tags(monkeypatch, aggregator):
     for metric in METRICS_WITH_INTERFACE_TAG:
         tag = 'interface:%s' % METRICS_WITH_INTERFACE_TAG[metric]
         aggregator.assert_metric_has_tag(metric, tag)
+
+def test_silent_tls_warning(caplog, monkeypatch, aggregator):
+    check = KubeletCheck('kubelet', {}, [{}])
+    check.kube_health_url = "https://example.com/"
+    check.kubelet_credentials = KubeletCredentials({'verify_tls': 'false'})
+
+    with caplog.at_level(logging.DEBUG):
+        check._perform_kubelet_check([])
+
+    expected_message = 'An unverified HTTPS request is being made to https://example.com/'
+    for _, _, message in caplog.record_tuples:
+        assert message != expected_message

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
+import logging
 import os
 import sys
 from datetime import datetime
@@ -615,7 +616,7 @@ def test_report_node_metrics(monkeypatch):
     check.gauge.assert_has_calls(calls, any_order=False)
 
 def test_report_node_metrics_kubernetes1_18(monkeypatch, aggregator):
-    check = KubeletCheck('kubelet', {}, [{}])
+    check = KubeletCheck('kubelet', None, {}, [{}])
     check.kubelet_credentials = KubeletCredentials({'verify_tls': 'false'})
     check.node_spec_url = "http://localhost:10255/spec"
 
@@ -682,7 +683,7 @@ def test_add_labels_to_tags(monkeypatch, aggregator):
         aggregator.assert_metric_has_tag(metric, tag)
 
 def test_silent_tls_warning(caplog, monkeypatch, aggregator):
-    check = KubeletCheck('kubelet', {}, [{}])
+    check = KubeletCheck('kubelet', None, {}, [{}])
     check.kube_health_url = "https://example.com/"
     check.kubelet_credentials = KubeletCredentials({'verify_tls': 'false'})
 

--- a/stackstate_checks_base/stackstate_checks/base/log.py
+++ b/stackstate_checks_base/stackstate_checks/base/log.py
@@ -3,12 +3,15 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
 
+import warnings
+
 try:
     import datadog_agent
 except ImportError:
     from .stubs import datadog_agent
 
 from .utils.common import to_string
+from urllib3.exceptions import InsecureRequestWarning
 
 # Arbitrary number less than 10 (DEBUG)
 TRACE_LEVEL = 7
@@ -67,6 +70,9 @@ def init_logging():
     rootLogger = logging.getLogger()
     rootLogger.addHandler(AgentLogHandler())
     rootLogger.setLevel(_get_py_loglevel(datadog_agent.get_config('log_level')))
+
+    # We log instead of emit warnings for unintentionally insecure HTTPS requests
+    warnings.simplefilter('ignore', InsecureRequestWarning)
 
     # `requests` (used in a lot of checks) imports `urllib3`, which logs a bunch of stuff at the info level
     # Therefore, pre emptively increase the default level of that logger to `WARN`


### PR DESCRIPTION
### Step 1: Link to Jira issue
https://stackstate.atlassian.net/browse/STAC-12307

### Step 2: Description of changes
Support Kubernetes 1.18 which has deprecated the `/spec` endpoint on the kubelet api
Next to that some minor improvements to the verbosity and helpfulness of the error logging

### Step 3: Did you add / update tests for your changes in the right area?
- [x] Unit/Component test
- [ ] Integration test	


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: