### PR TITLE
STAC-12806 aws_xray no role_arn fix

### DIFF
--- a/aws_xray/.gitignore
+++ b/aws_xray/.gitignore
@@ -1,0 +1,1 @@
+run_aws_xray_check.py

--- a/aws_xray/stackstate_checks/aws_xray/aws_xray.py
+++ b/aws_xray/stackstate_checks/aws_xray/aws_xray.py
@@ -258,6 +258,9 @@ class AwsClient:
             self.aws_access_key_id = role['Credentials']['AccessKeyId']
             self.aws_secret_access_key = role['Credentials']['SecretAccessKey']
             self.aws_session_token = role['Credentials']['SessionToken']
+        else:
+            self.aws_access_key_id = aws_access_key_id
+            self.aws_secret_access_key = aws_secret_access_key
 
     def get_account_id(self):
         return self._get_boto3_client('sts').get_caller_identity().get('Account')

--- a/aws_xray/tests/conftest.py
+++ b/aws_xray/tests/conftest.py
@@ -17,3 +17,12 @@ def instance():
         'role_arn': 'arn:aws:iam::0123456789:role/OtherRoleName',
         'region': 'ijk'
     }
+
+
+@pytest.fixture
+def instance_no_role_arn():
+    return {
+        'aws_access_key_id': 'abc',
+        'aws_secret_access_key': 'cde',
+        'region': 'ijk'
+    }

--- a/aws_xray/tests/test_aws.py
+++ b/aws_xray/tests/test_aws.py
@@ -14,7 +14,7 @@ AWS_REGION = 'eu-west-1'
 AWS_ACCOUNT = '672574731473'
 
 
-class MockAwsClient():
+class MockAwsClient:
     def __init__(self, instance, init_config):
         self.region = AWS_REGION
 
@@ -72,6 +72,15 @@ def test_service_check_ok(aggregator, instance):
     assert aws_check.get_instance_key(instance) == TopologyInstance('aws', AWS_ACCOUNT)
     aggregator.assert_service_check('aws_xray.can_connect', aws_check.OK)
     aggregator.assert_service_check('aws_xray.can_execute', aws_check.OK)
+
+
+def test_no_role_arn(aggregator, instance_no_role_arn):
+    aws_check = AwsCheck('test', {}, {}, instances=[instance_no_role_arn])
+    assert aws_check.get_instance_key(instance_no_role_arn) == TopologyInstance('aws', 'unknown-instance')
+    aws_client = AwsClient(instance_no_role_arn, config={})
+    assert aws_client.aws_access_key_id == instance_no_role_arn.get('aws_access_key_id')
+    assert aws_client.aws_secret_access_key == instance_no_role_arn.get('aws_secret_access_key')
+    assert aws_client.aws_session_token is None
 
 
 def test_span_generation():

--- a/stackstate-changelog.md
+++ b/stackstate-changelog.md
@@ -1,5 +1,9 @@
 # StackState Agent Integrations v2 releases
 
+## 1.13.3 / 2021-04-23
+
+* [Fixed] AWS x-ray check error when `role_arn` is not defined in `conf.yaml`
+
 ## 1.13.2 / 2021-04-19
 
 * [Fixed] Fixed out-of-box AWS x-ray check instance error.


### PR DESCRIPTION
### Step 1: Link to Jira issue
https://stackstate.atlassian.net/browse/STAC-12806

### Step 2: Description of changes
Fixed issue when `role_arn` is not defined in `conf.yaml`

### Step 3: Did you add / update tests for your changes in the right area?
- [x] Unit/Component test
- [ ] Integration test	


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Johnny

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: