### PR TITLE
Stac 12217 multi aws account region

### DIFF
--- a/aws_topology/.gitignore
+++ b/aws_topology/.gitignore
@@ -1,0 +1,1 @@
+run_aws_topology.py

--- a/aws_topology/stackstate_checks/aws_topology/__init__.py
+++ b/aws_topology/stackstate_checks/aws_topology/__init__.py
@@ -2,11 +2,12 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from .__about__ import __version__
-from .aws_topology import AwsTopologyCheck, AwsClient, InstanceInfo
+from .aws_topology import AwsTopologyCheck, AwsClient, InstanceInfo, InitConfig
 
 __all__ = [
     '__version__',
     'AwsTopologyCheck',
     'AwsClient',
     'InstanceInfo',
+    'InitConfig'
 ]

--- a/aws_topology/stackstate_checks/aws_topology/aws_topology.py
+++ b/aws_topology/stackstate_checks/aws_topology/aws_topology.py
@@ -100,7 +100,7 @@ class AwsTopologyCheck(AgentCheck):
                 keys.append(keys.pop(keys.index('cloudformation')))
             for api in keys:
                 client = session.client(api)
-                location = location_info(self.get_account_id(instance_info), session.region)
+                location = location_info(self.get_account_id(instance_info), session.region_name)
                 for part in registry[api]:
                     if instance_info.apis_to_run is not None:
                         if not (api + '|' + part) in instance_info.apis_to_run:

--- a/aws_topology/stackstate_checks/aws_topology/aws_topology.py
+++ b/aws_topology/stackstate_checks/aws_topology/aws_topology.py
@@ -5,6 +5,7 @@ import logging
 import boto3
 import time
 import traceback
+from botocore.exceptions import ClientError
 from schematics import Model
 from schematics.types import StringType, ListType, DictType
 from botocore.config import Config
@@ -23,12 +24,15 @@ DEFAULT_BOTO3_CONFIG = Config(
 DEFAULT_COLLECTION_INTERVAL = 60
 
 
-class InstanceInfo(Model):
-    region = StringType(required=True)
+class InitConfig(Model):
     aws_access_key_id = StringType(required=True)
     aws_secret_access_key = StringType(required=True)
+    external_id = StringType(required=True)
+
+
+class InstanceInfo(Model):
     role_arn = StringType(required=True)
-    account_id = StringType(required=True)
+    regions = ListType(StringType)
     tags = ListType(StringType, default=[])
     arns = DictType(StringType, default={})
     apis_to_run = ListType(StringType)
@@ -41,19 +45,15 @@ class AwsTopologyCheck(AgentCheck):
     SERVICE_CHECK_EXECUTE_NAME = 'aws_topology.can_execute'
     INSTANCE_SCHEMA = InstanceInfo
 
+    def get_account_id(self, instance_info):
+        return instance_info.role_arn.split(':')[4]
+
     def get_instance_key(self, instance_info):
-        return TopologyInstance(self.INSTANCE_TYPE, str(instance_info.account_id))
+        return TopologyInstance(self.INSTANCE_TYPE, str(self.get_account_id(instance_info)))
 
     def check(self, instance_info):
         try:
-            aws_client = AwsClient(instance_info, self.init_config)
-            instance_info.region = aws_client.region
-            account_id = aws_client.get_account_id()
-            if not account_id == instance_info.account_id:
-                raise Exception(
-                    "AWS caller identity does not return correct account_id. %s was returned, but %s was expected." %
-                    (account_id, instance_info.account_id)
-                )
+            aws_client = AwsClient(self.init_config)
             self.service_check(self.SERVICE_CHECK_CONNECT_NAME, AgentCheck.OK, tags=instance_info.tags)
         except Exception as e:
             msg = 'AWS connection failed: {}'.format(e)
@@ -86,55 +86,59 @@ class AwsTopologyCheck(AgentCheck):
         self.memory_data = {}  # name -> arn for cloudformation
         errors = []
         self.delete_ids = []
-        registry = ResourceRegistry.get_registry()
-        keys = [key for key in registry.keys()]
-        if instance_info.apis_to_run is not None:
-            keys = [api.split('|')[0] for api in instance_info.apis_to_run]
-        # move cloudformation to the end
-        if 'cloudformation' in keys:
-            keys.append(keys.pop(keys.index('cloudformation')))
-        for api in keys:
-            global_api = api.startswith('route53')
-            client = aws_client.get_boto3_client(api, region='us-east-1' if global_api else None)
-            location = location_info(instance_info.account_id, 'us-east-1' if global_api else instance_info.region)
-            for part in registry[api]:
-                if instance_info.apis_to_run is not None:
-                    if not (api + '|' + part) in instance_info.apis_to_run:
-                        continue
-                processor = registry[api][part](location, client, self)
-                try:
-                    if api != 'cloudformation':
-                        result = processor.process_all()
-                    else:
-                        result = processor.process_all(self.memory_data)
-                    if result:
-                        memory_key = processor.MEMORY_KEY or api
-                        if memory_key != "MULTIPLE":
-                            if self.memory_data.get(memory_key) is not None:
-                                self.memory_data[memory_key].update(result)
-                            else:
-                                self.memory_data[memory_key] = result
+
+        for region in instance_info.regions:
+            session = aws_client.get_session(instance_info.role_arn, region)
+            registry = ResourceRegistry.get_registry()["regional" if region != "global" else "global"]
+            keys = (
+                [key for key in registry.keys()]
+                if instance_info.apis_to_run is None
+                else [api.split('|')[0] for api in instance_info.apis_to_run]
+            )
+            # move cloudformation to the end
+            if 'cloudformation' in keys:
+                keys.append(keys.pop(keys.index('cloudformation')))
+            for api in keys:
+                client = session.client(api)
+                location = location_info(self.get_account_id(instance_info), session.region)
+                for part in registry[api]:
+                    if instance_info.apis_to_run is not None:
+                        if not (api + '|' + part) in instance_info.apis_to_run:
+                            continue
+                    processor = registry[api][part](location, client, self)
+                    try:
+                        if api != 'cloudformation':
+                            result = processor.process_all()
                         else:
-                            for rk in result:
-                                if self.memory_data.get(rk) is not None:
-                                    self.memory_data[rk].update(result[rk])
+                            result = processor.process_all(self.memory_data)
+                        if result:
+                            memory_key = processor.MEMORY_KEY or api
+                            if memory_key != "MULTIPLE":
+                                if self.memory_data.get(memory_key) is not None:
+                                    self.memory_data[memory_key].update(result)
                                 else:
-                                    self.memory_data[rk] = result[rk]
-                    self.delete_ids += processor.get_delete_ids()
-                except Exception as e:
-                    event = {
-                        'timestamp': int(time.time()),
-                        'event_type': 'aws_agent_check_error',
-                        'msg_title': e.__class__.__name__ + " in api " + api + " component_type " + part,
-                        'msg_text': str(e),
-                        'tags': [
-                            'aws_region:' + location["Location"]["AwsRegion"],
-                            'account_id:' + location["Location"]["AwsAccount"],
-                            'process:' + api + "|" + part
-                        ]
-                    }
-                    self.event(event)
-                    errors.append('API %s ended with exception: %s %s' % (api, str(e), traceback.format_exc()))
+                                    self.memory_data[memory_key] = result
+                            else:
+                                for rk in result:
+                                    if self.memory_data.get(rk) is not None:
+                                        self.memory_data[rk].update(result[rk])
+                                    else:
+                                        self.memory_data[rk] = result[rk]
+                        self.delete_ids += processor.get_delete_ids()
+                    except Exception as e:
+                        event = {
+                            'timestamp': int(time.time()),
+                            'event_type': 'aws_agent_check_error',
+                            'msg_title': e.__class__.__name__ + " in api " + api + " component_type " + part,
+                            'msg_text': str(e),
+                            'tags': [
+                                'aws_region:' + location["Location"]["AwsRegion"],
+                                'account_id:' + location["Location"]["AwsAccount"],
+                                'process:' + api + "|" + part
+                            ]
+                        }
+                        self.event(event)
+                        errors.append('API %s ended with exception: %s %s' % (api, str(e), traceback.format_exc()))
         if len(errors) > 0:
             raise Exception('get_topology gave following exceptions: %s' % ', '.join(errors))
 
@@ -142,35 +146,56 @@ class AwsTopologyCheck(AgentCheck):
 
 
 class AwsClient:
-    def __init__(self, instance, config):
+    def __init__(self, config):
         self.log = logging.getLogger(__name__)
         self.log.setLevel(logging.INFO)
+        self.external_id = config.external_id
+        self.aws_access_key_id = config.aws_access_key_id
+        self.aws_secret_access_key = config.aws_secret_access_key
 
-        aws_access_key_id = instance.aws_access_key_id
-        aws_secret_access_key = instance.aws_secret_access_key
-        role_arn = instance.role_arn
-        self.region = instance.region
-        self.aws_session_token = None
-
-        if aws_secret_access_key and aws_access_key_id and role_arn and self.region:
-            sts_client = boto3.client(
+        if self.aws_secret_access_key and self.aws_access_key_id:
+            self.sts_client = boto3.client(
                 'sts',
                 config=DEFAULT_BOTO3_CONFIG,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key
+                aws_access_key_id=self.aws_access_key_id,
+                aws_secret_access_key=self.aws_secret_access_key
             )
-            role = sts_client.assume_role(RoleArn=role_arn, RoleSessionName='sts-agent-check')
-            self.aws_access_key_id = role['Credentials']['AccessKeyId']
-            self.aws_secret_access_key = role['Credentials']['SecretAccessKey']
-            self.aws_session_token = role['Credentials']['SessionToken']
-        if self.aws_session_token is None:
-            raise Exception("Received no session token during AWS client initialization")
+        else:
+            # Rely on credential provider chain to find credentials
+            try:
+                self.sts_client = boto3.client(
+                    'sts',
+                    config=DEFAULT_BOTO3_CONFIG
+                )
+            except Exception as e:
+                raise Exception('No credentials found, the following exception was given: %s' % e)
 
-    def get_account_id(self):
-        return self.get_boto3_client('sts').get_caller_identity().get('Account')
+    def get_session(self, role_arn, region):
+        try:
+            # This should fail as it means it was able to successfully use the role without an external ID
+            role = self.sts_client.assume_role(RoleArn=role_arn, RoleSessionName='sts-agent-id-test')
+            # This override should not be (publicly) documented
+            if self.external_id != 'disable_external_id_this_is_unsafe':
+                raise Exception(
+                    'No external ID has been set for this role.' +
+                    'For security reasons, please set the external ID.'
+                )
+        except ClientError as error:
+            if error.response['Error']['Code'] == 'AccessDeniedException':
+                try:
+                    role = self.sts_client.assume_role(
+                        RoleArn=role_arn,
+                        RoleSessionName='sts-agent-check-%s' % region,
+                        ExternalId=self.external_id
+                        )
+                except Exception as error:
+                    raise Exception('Unable to assume role %s. Error: %s' % (role_arn, error))
+            else:
+                raise error
 
-    def get_boto3_client(self, service_name, region=None):
-        return boto3.client(service_name, region_name=region or self.region, config=DEFAULT_BOTO3_CONFIG,
-                            aws_access_key_id=self.aws_access_key_id,
-                            aws_secret_access_key=self.aws_secret_access_key,
-                            aws_session_token=self.aws_session_token)
+        return boto3.Session(
+            region_name=region if region != 'global' else 'us-east-1',
+            aws_access_key_id=role['Credentials']['AccessKeyId'],
+            aws_secret_access_key=role['Credentials']['SecretAccessKey'],
+            aws_session_token=role['Credentials']['SessionToken']
+        )

--- a/aws_topology/stackstate_checks/aws_topology/aws_topology.py
+++ b/aws_topology/stackstate_checks/aws_topology/aws_topology.py
@@ -53,7 +53,9 @@ class AwsTopologyCheck(AgentCheck):
 
     def check(self, instance_info):
         try:
-            aws_client = AwsClient(self.init_config)
+            init_config = InitConfig(self.init_config)
+            init_config.validate()
+            aws_client = AwsClient(init_config)
             self.service_check(self.SERVICE_CHECK_CONNECT_NAME, AgentCheck.OK, tags=instance_info.tags)
         except Exception as e:
             msg = 'AWS connection failed: {}'.format(e)

--- a/aws_topology/stackstate_checks/aws_topology/data/conf.yaml.example
+++ b/aws_topology/stackstate_checks/aws_topology/data/conf.yaml.example
@@ -1,6 +1,10 @@
+init_config:
+  aws_access_key_id: 'abc'
+  aws_secret_access_key: 'cde'
+  external_id: 'randomvalue'
+
 instances:
-  - aws_access_key_id: 'abc'
-    aws_secret_access_key: 'cde'
-    role_arn: 'arn:aws:iam::0123456789:role/RoleName'
-    account_id: '123456789012'
-    region: 'ijk'
+  - role_arn: arn:aws:iam::0123456789:role/RoleName
+    regions: 
+      - global
+      - eu-west-1

--- a/aws_topology/stackstate_checks/aws_topology/resources/api_gateway.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/api_gateway.py
@@ -11,6 +11,7 @@ except ImportError:
 
 class ApigatewayStageCollector(RegisteredResourceCollector):
     API = "apigateway"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.apigateway.stage"
     MEMORY_KEY = "api_stage"
 

--- a/aws_topology/stackstate_checks/aws_topology/resources/autoscaling.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/autoscaling.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class AutoscalingCollector(RegisteredResourceCollector):
     API = "autoscaling"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.autoscaling"
     MEMORY_KEY = "auto_scaling"
 

--- a/aws_topology/stackstate_checks/aws_topology/resources/cloudformation.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/cloudformation.py
@@ -23,6 +23,7 @@ type_map = {
 
 class CloudformationCollector(RegisteredResourceCollector):
     API = "cloudformation"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.cloudformation"
 
     def process_all(self, memory_data=None):

--- a/aws_topology/stackstate_checks/aws_topology/resources/dynamodb.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/dynamodb.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class DynamodbTableCollector(RegisteredResourceCollector):
     API = "dynamodb"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.dynamodb"
 
     def process_all(self):

--- a/aws_topology/stackstate_checks/aws_topology/resources/ec2.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/ec2.py
@@ -5,6 +5,7 @@ from .registry import RegisteredResourceCollector
 
 class Ec2InstanceCollector(RegisteredResourceCollector):
     API = "ec2"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.ec2"
 
     def __init__(self, location_info, client, agent):

--- a/aws_topology/stackstate_checks/aws_topology/resources/ec2_vpc.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/ec2_vpc.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class VpcCollector(RegisteredResourceCollector):
     API = "ec2"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.vpc"
 
     def process_all(self):

--- a/aws_topology/stackstate_checks/aws_topology/resources/ec2_vpn_gateway.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/ec2_vpn_gateway.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class VpnGatewayCollector(RegisteredResourceCollector):
     API = "ec2"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.vpngateway"
 
     def process_all(self):

--- a/aws_topology/stackstate_checks/aws_topology/resources/ecs.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/ecs.py
@@ -15,6 +15,7 @@ DEFAULT_BOTO3_CONFIG = Config(
 
 class EcsCollector(RegisteredResourceCollector):
     API = "ecs"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.ecs.cluster"
     MEMORY_KEY = "ecs_cluster"
 

--- a/aws_topology/stackstate_checks/aws_topology/resources/elb_classic.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/elb_classic.py
@@ -5,6 +5,7 @@ from .registry import RegisteredResourceCollector
 
 class ELBClassicCollector(RegisteredResourceCollector):
     API = "elb"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.elb_classic"
     MEMORY_KEY = "elb_classic"
 

--- a/aws_topology/stackstate_checks/aws_topology/resources/elb_v2.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/elb_v2.py
@@ -6,6 +6,7 @@ from .registry import RegisteredResourceCollector
 
 class ElbV2Collector(RegisteredResourceCollector):
     API = "elbv2"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.elb_v2"
     MEMORY_KEY = "MULTIPLE"
 

--- a/aws_topology/stackstate_checks/aws_topology/resources/firehose.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/firehose.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class FirehoseCollector(RegisteredResourceCollector):
     API = "firehose"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.firehose"
 
     def process_all(self):

--- a/aws_topology/stackstate_checks/aws_topology/resources/kinesis.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/kinesis.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class KinesisCollector(RegisteredResourceCollector):
     API = "kinesis"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.kinesis"
     MEMORY_KEY = "kinesis_stream"
 

--- a/aws_topology/stackstate_checks/aws_topology/resources/lambda_event_source_mapping.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/lambda_event_source_mapping.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class LambdaeventsourcemappingCollector(RegisteredResourceCollector):
     API = "lambda"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.lambda.event_source_mapping"
 
     def process_all(self):

--- a/aws_topology/stackstate_checks/aws_topology/resources/lambdaf.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/lambdaf.py
@@ -6,6 +6,7 @@ from .registry import RegisteredResourceCollector
 
 class LambdaCollector(RegisteredResourceCollector):
     API = "lambda"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.lambda"
     MEMORY_KEY = "lambda_func"
 

--- a/aws_topology/stackstate_checks/aws_topology/resources/rds.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/rds.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class RdsCollector(RegisteredResourceCollector):
     API = "rds"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.rds_cluster"
 
     def process_all(self):

--- a/aws_topology/stackstate_checks/aws_topology/resources/redshift.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/redshift.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class RedshiftCollector(RegisteredResourceCollector):
     API = "redshift"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.redshift"
 
     def process_all(self):

--- a/aws_topology/stackstate_checks/aws_topology/resources/registry.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/registry.py
@@ -4,7 +4,10 @@ from .utils import correct_tags, capitalize_keys
 
 class ResourceRegistry(type):
 
-    REGISTRY = {}
+    REGISTRY = {
+        'global': {},
+        'regional': {}
+    }
 
     def __new__(cls, name, bases, attrs):
         new_cls = type.__new__(cls, name, bases, attrs)
@@ -12,10 +15,10 @@ class ResourceRegistry(type):
             Here the name of the class is used as key but it could be any class
             parameter.
         """
-        if new_cls.API != '??':
-            if cls.REGISTRY.get(new_cls.API) is None:
-                cls.REGISTRY[new_cls.API] = {}
-            cls.REGISTRY[new_cls.API][new_cls.COMPONENT_TYPE] = new_cls
+        if '??' not in [new_cls.API, new_cls.API_TYPE]:
+            if cls.REGISTRY[new_cls.API_TYPE].get(new_cls.API) is None:
+                cls.REGISTRY[new_cls.API_TYPE][new_cls.API] = {}
+            cls.REGISTRY[new_cls.API_TYPE][new_cls.API][new_cls.COMPONENT_TYPE] = new_cls
         return new_cls
 
     @classmethod
@@ -55,6 +58,7 @@ class RegisteredResourceCollector(with_metaclass(ResourceRegistry, object)):
     class and the associated value, the class itself.
     """
     API = "??"
+    API_TYPE = "??"
     MEMORY_KEY = None
     COMPONENT_TYPE = "??"
 

--- a/aws_topology/stackstate_checks/aws_topology/resources/route53_domain.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/route53_domain.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class Route53DomainCollector(RegisteredResourceCollector):
     API = "route53domains"
+    API_TYPE = "global"
     COMPONENT_TYPE = "aws.route53.domain"
 
     def process_all(self):

--- a/aws_topology/stackstate_checks/aws_topology/resources/route53_hostedzone.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/route53_hostedzone.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class Route53HostedzoneCollector(RegisteredResourceCollector):
     API = "route53"
+    API_TYPE = "global"
     COMPONENT_TYPE = "aws.route53.hostedzone"
 
     def process_all(self):

--- a/aws_topology/stackstate_checks/aws_topology/resources/s3.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/s3.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class S3Collector(RegisteredResourceCollector):
     API = "s3"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.s3_bucket"
 
     def process_all(self):

--- a/aws_topology/stackstate_checks/aws_topology/resources/security_group.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/security_group.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class SecuritygroupCollector(RegisteredResourceCollector):
     API = "ec2"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.security-group"
 
     def process_all(self):

--- a/aws_topology/stackstate_checks/aws_topology/resources/sns.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/sns.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class SnsCollector(RegisteredResourceCollector):
     API = "sns"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.sns"
 
     def process_all(self):

--- a/aws_topology/stackstate_checks/aws_topology/resources/sqs.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/sqs.py
@@ -4,6 +4,7 @@ from .registry import RegisteredResourceCollector
 
 class SqsCollector(RegisteredResourceCollector):
     API = "sqs"
+    API_TYPE = "regional"
     COMPONENT_TYPE = "aws.sqs"
 
     def process_all(self):

--- a/aws_topology/tests/conftest.py
+++ b/aws_topology/tests/conftest.py
@@ -32,21 +32,35 @@ def sts_environment():
     #  The start command places this as a `conf.yaml` in the `conf.d/mycheck/` directory.
     #  If you want to run an environment this object can not be empty.
     return {
-        "aws_access_key_id": "some_key",
-        "aws_secret_access_key": "some_secret",
-        "role_arn": "some_role",
-        "account_id": "123456789012",
-        "region": "eu-west-1"
+        "role_arn": "arn:aws:iam::123456789012:role/RoleName",
+        "regions": ["eu-west-1"],
     }
 
 
 @pytest.fixture(scope="class")
 def instance(request):
     cfg = {
-        "aws_access_key_id": "some_key",
-        "aws_secret_access_key": "some_secret",
-        "role_arn": "some_role",
-        "account_id": "123456789012",
-        "region": "eu-west-1"
+            "role_arn": "arn:aws:iam::123456789012:role/RoleName",
+            "regions": ["eu-west-1"],
     }
     request.cls.instance = cfg
+
+
+@pytest.fixture(scope="class")
+def init_config(request):
+    cfg = {
+        "aws_access_key_id": "abc",
+        "aws_secret_access_key": "cde",
+        "external_id": "randomvalue"
+    }
+    request.cls.config = cfg
+
+
+@pytest.fixture(scope="class")
+def init_config_override(request):
+    cfg = {
+        "aws_access_key_id": "abc",
+        "aws_secret_access_key": "cde",
+        "external_id": "disable_external_id_this_is_unsafe",
+    }
+    request.cls.config = cfg

--- a/aws_topology/tests/test_aws_client.py
+++ b/aws_topology/tests/test_aws_client.py
@@ -3,23 +3,30 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import unittest
 from mock import patch
+import botocore
 
-from stackstate_checks.aws_topology import AwsClient, InstanceInfo
+from stackstate_checks.aws_topology import AwsClient, InstanceInfo, InitConfig
 
-REGION = "test-region"
+REGIONS = ["test-region"]
 KEY_ID = "1234"
 ACCESS_KEY = "5678"
 ACCOUNT_ID = "123456789012"
-ROLE = "some_role_with_many_characters"
+ROLE = "arn:aws:iam::123456789012:role/RoleName"
 TOKEN = "ABCDE"
+EXTERNAL_ID = "ABCDE"
 
-instance = InstanceInfo(
+init_config = InitConfig(
     {
         "aws_access_key_id": KEY_ID,
         "aws_secret_access_key": ACCESS_KEY,
+        "external_id": EXTERNAL_ID
+    }
+)
+
+instance = InstanceInfo(
+    {
         "role_arn": ROLE,
-        "account_id": ACCOUNT_ID,
-        "region": REGION
+        "regions": REGIONS,
     }
 )
 
@@ -31,69 +38,83 @@ instance_no_input = InstanceInfo({
 class TestAWSClient(unittest.TestCase):
     """Basic Test for AWS Topology integration."""
 
-    def test_no_token_gives_exception(self):
-        def results(operation_name, kwarg):
-            api_results = {
-                'AssumeRole': {
+    # def test_no_token_gives_exception(self):
+    #     def results(operation_name, kwarg):
+    #         api_results = {
+    #             'AssumeRole': {
+    #                 "Credentials": {
+    #                     "AccessKeyId": KEY_ID,
+    #                     "SecretAccessKey": ACCESS_KEY,
+    #                     "SessionToken": None
+    #                 }
+    #             }
+    #         }
+    #         return api_results[operation_name]
+    #     with patch('botocore.client.BaseClient._make_api_call') as mock_method:
+    #         mock_method.side_effect = results
+    #         with self.assertRaises(Exception) as context:
+    #             AwsClient(init_config)
+    #     self.assertIn('no session token', str(context.exception))
+
+    def test_no_external_id_gives_exception(self):
+        def results(operation_name, api_params):
+            if operation_name == 'AssumeRole' and 'external_id' in api_params:
+                return {
                     "Credentials": {
                         "AccessKeyId": KEY_ID,
                         "SecretAccessKey": ACCESS_KEY,
-                        "SessionToken": None
+                        "SessionToken": TOKEN
                     }
                 }
-            }
-            return api_results[operation_name]
+            else:
+                raise botocore.exceptions.ClientError({
+                    'Error': {
+                        'Code': 'AccessDeniedException'
+                    }
+                }, operation_name)
         with patch('botocore.client.BaseClient._make_api_call') as mock_method:
             mock_method.side_effect = results
             with self.assertRaises(Exception) as context:
-                AwsClient(instance, {})
-        self.assertIn('no session token', str(context.exception))
+                client = AwsClient(InitConfig(
+                    {
+                        "aws_access_key_id": KEY_ID,
+                        "aws_secret_access_key": ACCESS_KEY
+                    }
+                ))
+                client.get_session(instance['regions'][0], instance['role_arn'])
+        self.assertIn('AccessDeniedException', str(context.exception))
 
     def test_no_input_gives_exception(self):
         with self.assertRaises(Exception) as context:
-            AwsClient(instance_no_input, {})
-        self.assertIn('no session token', str(context.exception))
+            AwsClient(instance_no_input)
+        self.assertIn('external_id', str(context.exception))
 
     def test_client_connect(self):
-        api_results = {
-            'AssumeRole': {
-                "Credentials": {
-                    "AccessKeyId": KEY_ID,
-                    "SecretAccessKey": ACCESS_KEY,
-                    "SessionToken": TOKEN
+        def results(operation_name, api_params):
+            if operation_name == 'AssumeRole' and 'ExternalId' in api_params:
+                return {
+                    "Credentials": {
+                        "AccessKeyId": KEY_ID,
+                        "SecretAccessKey": ACCESS_KEY,
+                        "SessionToken": TOKEN
+                    }
                 }
-            }
-        }
-
-        def results(operation_name, kwarg):
-            return api_results[operation_name]
+            else:
+                raise botocore.exceptions.ClientError({
+                    'Error': {
+                        'Code': 'AccessDeniedException'
+                    }
+                }, operation_name)
         with patch('botocore.client.BaseClient._make_api_call') as mock_method:
             mock_method.side_effect = results
-            client = AwsClient(instance, {})
-        self.assertEqual(client.region, REGION)
-        self.assertEqual(client.aws_access_key_id, KEY_ID)
-        self.assertEqual(client.aws_secret_access_key, ACCESS_KEY)
-        self.assertEqual(client.aws_session_token, TOKEN)
-        assert mock_method.called_once_with('AssumeRole', {'RoleArn': ROLE, 'RoleSessionName': 'sts-agent-check'})
-
-    def test_get_account_id(self):
-        api_results = {
-            'AssumeRole': {
-                "Credentials": {
-                    "AccessKeyId": KEY_ID,
-                    "SecretAccessKey": ACCESS_KEY,
-                    "SessionToken": TOKEN
-                }
-            },
-            'GetCallerIdentity': {
-                "Account": ACCOUNT_ID,
-            }
-        }
-
-        def results(operation_name, kwarg):
-            return api_results[operation_name]
-        with patch('botocore.client.BaseClient._make_api_call') as mock_method:
-            mock_method.side_effect = results
-            client = AwsClient(instance, {})
-            id = client.get_account_id()
-        self.assertEqual(id, ACCOUNT_ID)
+            client = AwsClient(init_config)
+            session = client.get_session(instance['role_arn'], instance['regions'][0])
+        self.assertEqual(session.region_name, REGIONS[0])
+        self.assertEqual(session.get_credentials().access_key, KEY_ID)
+        self.assertEqual(session.get_credentials().secret_key, ACCESS_KEY)
+        self.assertEqual(session.get_credentials().token, TOKEN)
+        assert mock_method.called_once_with('AssumeRole', {
+            'RoleArn': ROLE,
+            'RoleSessionName': 'sts-agent-check',
+            'ExternalId': EXTERNAL_ID
+        })

--- a/aws_topology/tests/test_aws_topology.py
+++ b/aws_topology/tests/test_aws_topology.py
@@ -55,7 +55,7 @@ class TestAWSTopologyCheck(unittest.TestCase):
         self.api_results = deepcopy(API_RESULTS)
         topology.reset()
         aggregator.reset()
-        self.check = AwsTopologyCheck(self.CHECK_NAME, config, [InstanceInfo(self.instance)])
+        self.check = AwsTopologyCheck(self.CHECK_NAME, config, [self.instance])
 
         def results(operation_name, api_params):
             if operation_name == 'AssumeRole' and 'ExternalId' not in api_params:

--- a/aws_topology/tests/test_ec2_vpn_gateway.py
+++ b/aws_topology/tests/test_ec2_vpn_gateway.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 
 from stackstate_checks.base.stubs import topology, aggregator
 from stackstate_checks.base import AgentCheck
-from stackstate_checks.aws_topology import AwsTopologyCheck, InitConfig, InstanceInfo
+from stackstate_checks.aws_topology import AwsTopologyCheck, InitConfig
 
 from .conftest import API_RESULTS
 
@@ -49,7 +49,7 @@ class TestVpnGateway(unittest.TestCase):
         self.api_results = deepcopy(API_RESULTS)
         topology.reset()
         aggregator.reset()
-        self.check = AwsTopologyCheck(self.CHECK_NAME, config, [InstanceInfo(self.instance)])
+        self.check = AwsTopologyCheck(self.CHECK_NAME, config, [self.instance])
 
         def results(operation_name, kwarg):
             return self.api_results.get(operation_name) or {}

--- a/aws_topology/tests/test_ec2_vpn_gateway.py
+++ b/aws_topology/tests/test_ec2_vpn_gateway.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 
 from stackstate_checks.base.stubs import topology, aggregator
 from stackstate_checks.base import AgentCheck
-from stackstate_checks.aws_topology import AwsTopologyCheck
+from stackstate_checks.aws_topology import AwsTopologyCheck, InitConfig, InstanceInfo
 
 from .conftest import API_RESULTS
 
@@ -37,13 +37,19 @@ class TestVpnGateway(unittest.TestCase):
         """
         Initialize and patch the check, i.e.
         """
-        config = {}
+        config = InitConfig(
+            {
+                "aws_access_key_id": "some_key",
+                "aws_secret_access_key": "some_secret",
+                "external_id": "disable_external_id_this_is_unsafe"
+            }
+        )
         self.patcher = patch('botocore.client.BaseClient._make_api_call')
         self.mock_object = self.patcher.start()
         self.api_results = deepcopy(API_RESULTS)
         topology.reset()
         aggregator.reset()
-        self.check = AwsTopologyCheck(self.CHECK_NAME, config, instances=[self.instance])
+        self.check = AwsTopologyCheck(self.CHECK_NAME, config, [InstanceInfo(self.instance)])
 
         def results(operation_name, kwarg):
             return self.api_results.get(operation_name) or {}

--- a/aws_topology/tests/test_s3.py
+++ b/aws_topology/tests/test_s3.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 
 from stackstate_checks.base.stubs import topology, aggregator
 from stackstate_checks.base import AgentCheck
-from stackstate_checks.aws_topology import AwsTopologyCheck
+from stackstate_checks.aws_topology import AwsTopologyCheck, InitConfig, InstanceInfo
 
 from .conftest import API_RESULTS
 
@@ -37,13 +37,19 @@ class TestS3(unittest.TestCase):
         """
         Initialize and patch the check, i.e.
         """
-        config = {}
+        config = InitConfig(
+            {
+                "aws_access_key_id": "some_key",
+                "aws_secret_access_key": "some_secret",
+                "external_id": "disable_external_id_this_is_unsafe"
+            }
+        )
         self.patcher = patch('botocore.client.BaseClient._make_api_call')
         self.mock_object = self.patcher.start()
         self.api_results = deepcopy(API_RESULTS)
         topology.reset()
         aggregator.reset()
-        self.check = AwsTopologyCheck(self.CHECK_NAME, config, instances=[self.instance])
+        self.check = AwsTopologyCheck(self.CHECK_NAME, config, [InstanceInfo(self.instance)])
 
         def results(operation_name, kwarg):
             return self.api_results.get(operation_name) or {}

--- a/aws_topology/tests/test_s3.py
+++ b/aws_topology/tests/test_s3.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 
 from stackstate_checks.base.stubs import topology, aggregator
 from stackstate_checks.base import AgentCheck
-from stackstate_checks.aws_topology import AwsTopologyCheck, InitConfig, InstanceInfo
+from stackstate_checks.aws_topology import AwsTopologyCheck, InitConfig
 
 from .conftest import API_RESULTS
 
@@ -49,7 +49,7 @@ class TestS3(unittest.TestCase):
         self.api_results = deepcopy(API_RESULTS)
         topology.reset()
         aggregator.reset()
-        self.check = AwsTopologyCheck(self.CHECK_NAME, config, [InstanceInfo(self.instance)])
+        self.check = AwsTopologyCheck(self.CHECK_NAME, config, [self.instance])
 
         def results(operation_name, kwarg):
             return self.api_results.get(operation_name) or {}

--- a/aws_topology/tests/test_sns.py
+++ b/aws_topology/tests/test_sns.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 
 from stackstate_checks.base.stubs import topology, aggregator
 from stackstate_checks.base import AgentCheck
-from stackstate_checks.aws_topology import AwsTopologyCheck
+from stackstate_checks.aws_topology import AwsTopologyCheck, InitConfig, InstanceInfo
 
 from .conftest import API_RESULTS
 
@@ -37,13 +37,19 @@ class TestSns(unittest.TestCase):
         """
         Initialize and patch the check, i.e.
         """
-        config = {}
+        config = InitConfig(
+            {
+                "aws_access_key_id": "some_key",
+                "aws_secret_access_key": "some_secret",
+                "external_id": "disable_external_id_this_is_unsafe"
+            }
+        )
         self.patcher = patch('botocore.client.BaseClient._make_api_call')
         self.mock_object = self.patcher.start()
         self.api_results = deepcopy(API_RESULTS)
         topology.reset()
         aggregator.reset()
-        self.check = AwsTopologyCheck(self.CHECK_NAME, config, instances=[self.instance])
+        self.check = AwsTopologyCheck(self.CHECK_NAME, config, [InstanceInfo(self.instance)])
 
         def results(operation_name, kwarg):
             return self.api_results.get(operation_name) or {}

--- a/aws_topology/tests/test_sns.py
+++ b/aws_topology/tests/test_sns.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 
 from stackstate_checks.base.stubs import topology, aggregator
 from stackstate_checks.base import AgentCheck
-from stackstate_checks.aws_topology import AwsTopologyCheck, InitConfig, InstanceInfo
+from stackstate_checks.aws_topology import AwsTopologyCheck, InitConfig
 
 from .conftest import API_RESULTS
 
@@ -49,7 +49,7 @@ class TestSns(unittest.TestCase):
         self.api_results = deepcopy(API_RESULTS)
         topology.reset()
         aggregator.reset()
-        self.check = AwsTopologyCheck(self.CHECK_NAME, config, [InstanceInfo(self.instance)])
+        self.check = AwsTopologyCheck(self.CHECK_NAME, config, [self.instance])
 
         def results(operation_name, kwarg):
             return self.api_results.get(operation_name) or {}


### PR DESCRIPTION
### Step 1: Link to Jira issue
https://stackstate.atlassian.net/browse/STAC-12217

### Step 2: Description of changes
Implement new IAM role assuming functionality, where the agent uses one global IAM access key/secret access key, then assumes a role into a each instance.

Provide a region list in each instance, and iterate through each region to fetch topology for every region in the list. A special "global" region exists and the registry categorizes global services. Global services are not queried in normal regions.

There are some concerns about handling large amounts of API calls and the limits of Python for parallelizing different regions, this will be tackled soon. For now each region is run in serial.

### Step 3: Did you add / update tests for your changes in the right area?
- [x] Unit/Component test
- [x] Integration test	


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: