### PR TITLE
Stac 13058 component rename

### DIFF
--- a/aws_topology/stackstate_checks/aws_topology/resources/kinesis.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/kinesis.py
@@ -68,6 +68,7 @@ class KinesisCollector(RegisteredResourceCollector):
         stream_summary_raw = self.client.describe_stream_summary(StreamName=stream_name)
         stream_summary = make_valid_data(stream_summary_raw)
         stream_tags = self.client.list_tags_for_stream(StreamName=stream_name).get('Tags') or []
+        stream_summary['Name'] = stream_name
         stream_summary['Tags'] = stream_tags
         stream_arn = stream_summary['StreamDescriptionSummary']['StreamARN']
         self.emit_component(stream_arn, self.COMPONENT_TYPE, stream_summary)

--- a/aws_topology/stackstate_checks/aws_topology/resources/sns.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/sns.py
@@ -84,8 +84,8 @@ class SnsCollector(RegisteredResourceCollector):
 
     def process_topic(self, topic_data):
         topic_arn = topic_data['TopicArn']
-        topic_data['Name'] = topic_arn
         topic_name = topic_arn.rsplit(':', 1)[-1]
+        topic_data['Name'] = topic_name
         topic_data.update(with_dimensions([{'key': 'TopicName', 'value': topic_name}]))
         topic_data["Tags"] = self.client.list_tags_for_resource(ResourceArn=topic_arn).get('Tags') or []
         self.emit_component(topic_arn, self.COMPONENT_TYPE, topic_data)

--- a/aws_topology/stackstate_checks/aws_topology/resources/sqs.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/sqs.py
@@ -9,7 +9,12 @@ def get_queue_name_from_url(url):
 
 
 def create_arn(region=None, account_id=None, resource_id=None, **kwargs):
-    return arn(resource='sqs', region='', account_id=account_id, resource_id=get_queue_name_from_url(resource_id))
+    return arn(
+        resource='sqs',
+        region=region,
+        account_id=account_id,
+        resource_id=get_queue_name_from_url(resource_id),
+    )
 
 
 class SqsEventBase(CloudTrailEventBase):
@@ -91,9 +96,10 @@ class SqsCollector(RegisteredResourceCollector):
         ).get('Attributes', {})
         queue_data = make_valid_data(queue_data_raw)
         queue_arn = queue_data.get('QueueArn')
+        queue_name = queue_arn.rsplit(':', 1)[-1]
         queue_data['Tags'] = self.client.list_queue_tags(QueueUrl=queue_url).get('Tags')
         queue_data['URN'] = [queue_url]
-        queue_data['Name'] = queue_url
+        queue_data['Name'] = queue_name
         queue_data['QueueUrl'] = queue_url
         queue_name = queue_url.rsplit('/', 1)[-1]
         queue_data.update(with_dimensions([{'key': 'QueueName', 'value': queue_name}]))

--- a/aws_topology/tests/test_cloudtrail.py
+++ b/aws_topology/tests/test_cloudtrail.py
@@ -164,7 +164,7 @@ class TestCloudtrail(unittest.TestCase):
         self.assertEqual(len(topology), 1)
         self.assert_executed_ok()
         self.assertEqual(len(topology[0]["components"]), 0)
-        self.assertIn('arn:aws:sqs::731070500579:DeletedQueue', self.check.delete_ids)
+        self.assertIn('arn:aws:sqs:eu-west-1:731070500579:DeletedQueue', self.check.delete_ids)
 
     @set_event('sqs_purge_queue')
     def test_process_sqs_purge_queue(self):

--- a/aws_topology/tests/test_sns.py
+++ b/aws_topology/tests/test_sns.py
@@ -13,6 +13,7 @@ from stackstate_checks.aws_topology import AwsTopologyCheck, InitConfig
 from .conftest import API_RESULTS
 
 TOPIC_ARN = "arn:aws:sns:eu-west-1:731070500579:my-topic-1"
+TOPIC_NAME = "my-topic-1"
 SIMPLE_SNS = {
     'ListTopics': {
         "Topics": [
@@ -71,7 +72,7 @@ class TestSns(unittest.TestCase):
         self.assertEqual(len(test_topology['components']), 1)
         self.assertEqual(test_topology['components'][0]['type'], 'aws.sns')
         self.assertEqual(test_topology['components'][0]['id'], TOPIC_ARN)
-        self.assertEqual(test_topology['components'][0]['data']['Name'], TOPIC_ARN)
+        self.assertEqual(test_topology['components'][0]['data']['Name'], TOPIC_NAME)
         self.assert_executed_ok()
 
     def test_bucket_with_tags(self):

--- a/aws_topology/tests/test_template.py
+++ b/aws_topology/tests/test_template.py
@@ -732,7 +732,7 @@ class TestTemplate(unittest.TestCase):
         self.assertEqual(
             topology[0]["components"][0]["data"]["TopicArn"], "arn:aws:sns:eu-west-1:731070500579:my-topic-1"
         )
-        self.assertEqual(topology[0]["components"][0]["data"]["Name"], "arn:aws:sns:eu-west-1:731070500579:my-topic-1")
+        self.assertEqual(topology[0]["components"][0]["data"]["Name"], "my-topic-1")
         self.assertEqual(topology[0]["components"][0]["data"]["Tags"]["SnsTagKey"], "SnsTagValue")
         self.assert_stream_dimensions(topology[0]["components"][0], [{"Key": "TopicName", "Value": "my-topic-1"}])
 
@@ -754,7 +754,7 @@ class TestTemplate(unittest.TestCase):
         self.assertEqual(topology[0]["components"][0]["data"]["Tags"], {"a": "b"})
         self.assertEqual(
             topology[0]["components"][0]["data"]["Name"],
-            "https://eu-west-1.queue.amazonaws.com/508573134510/STS_stackpack_test",
+            "STS_stackpack_test",
         )
         self.assertEqual(
             topology[0]["components"][0]["data"]["URN"],
@@ -863,16 +863,20 @@ class TestTemplate(unittest.TestCase):
         self.assertEqual(len(topology), 1)
         self.assertEqual(len(topology[0]["relations"]), 0)
         self.assertEqual(len(topology[0]["components"]), 4)
+        self.assertEqual(topology[0]["components"][0]["Name"], "stream_1")
         self.assertEqual(topology[0]["components"][0]["id"], base_stream_arn + "stream_1")  # DIFF
         self.assertEqual(topology[0]["components"][0]["type"], "aws.kinesis")  # DIFF
         self.assertEqual(
             topology[0]["components"][0]["data"]["StreamDescriptionSummary"]["StreamARN"],
             "arn:aws:kinesis:eu-west-1:731070500579:stream/stream_1",
         )
+        self.assertEqual(topology[0]["components"][1]["Name"], "stream_2")
         self.assertEqual(topology[0]["components"][1]["id"], base_stream_arn + "stream_2")  # DIFF
         self.assertEqual(topology[0]["components"][1]["type"], "aws.kinesis")  # DIFF
+        self.assertEqual(topology[0]["components"][2]["Name"], "stream_3")
         self.assertEqual(topology[0]["components"][2]["id"], base_stream_arn + "stream_3")  # DIFF
         self.assertEqual(topology[0]["components"][2]["type"], "aws.kinesis")  # DIFF
+        self.assertEqual(topology[0]["components"][3]["Name"], "stream_4")
         self.assertEqual(topology[0]["components"][3]["id"], base_stream_arn + "stream_4")  # DIFF
         self.assertEqual(topology[0]["components"][3]["type"], "aws.kinesis")  # DIFF
 


### PR DESCRIPTION
### Step 1: Link to Jira issue
https://stackstate.atlassian.net/browse/STAC-13058

### Step 2: Description of changes
Rename the SQS, SNS and Kinesis components to have more friendly user-facing names for each component, instead of using IDs, ARNs or other.

### Step 3: Did you add / update tests for your changes in the right area?
- [x] Unit/Component test
- [ ] Integration test	


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: