### PR TITLE
Send aws_topology snapshot before raising errors

### DIFF
--- a/aws_topology/stackstate_checks/aws_topology/aws_topology.py
+++ b/aws_topology/stackstate_checks/aws_topology/aws_topology.py
@@ -142,14 +142,14 @@ class AwsTopologyCheck(AgentCheck):
                     }
                     self.event(event)
                     errors.append("API %s ended with exception: %s %s" % (spec["api"], str(e), traceback.format_exc()))
-            # TODO this should be for tests, in production these relations should not be sent out
-            agent_proxy.finalize_account_topology()
-            self.components_seen = agent_proxy.components_seen
-            if len(errors) > 0:
-                raise Exception("get_topology gave following exceptions: %s" % ", ".join(errors))
-        self.delete_ids += agent_proxy.delete_ids
+        # TODO this should be for tests, in production these relations should not be sent out
+        agent_proxy.finalize_account_topology()
+        self.components_seen = agent_proxy.components_seen
 
         self.stop_snapshot()
+        if len(errors) > 0:
+            raise Exception("get_topology gave following exceptions: %s" % ", ".join(errors))
+        self.delete_ids += agent_proxy.delete_ids
 
     def get_topology_update(self, instance_info, aws_client):
         agent_proxy = AgentProxy(self, instance_info.role_arn)

--- a/aws_topology/stackstate_checks/aws_topology/aws_topology.py
+++ b/aws_topology/stackstate_checks/aws_topology/aws_topology.py
@@ -145,11 +145,11 @@ class AwsTopologyCheck(AgentCheck):
         # TODO this should be for tests, in production these relations should not be sent out
         agent_proxy.finalize_account_topology()
         self.components_seen = agent_proxy.components_seen
+        self.delete_ids += agent_proxy.delete_ids
 
         self.stop_snapshot()
         if len(errors) > 0:
             raise Exception("get_topology gave following exceptions: %s" % ", ".join(errors))
-        self.delete_ids += agent_proxy.delete_ids
 
     def get_topology_update(self, instance_info, aws_client):
         agent_proxy = AgentProxy(self, instance_info.role_arn)


### PR DESCRIPTION
### Step 1: Link to Jira issue
https://stackstate.atlassian.net/browse/STAC-13287

### Step 2: Description of changes
Ensure that `stop_snapshot` is called before raising all found errors, to ensure that one failing API does not block the sending of successful APIs.

### Step 3: Did you add / update tests for your changes in the right area?
- [x] Unit/Component test
- [ ] Integration test	


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: