### PR TITLE
STAC-13505 fixing relation names for templates move to mapper function

### DIFF
--- a/aws_topology/stackstate_checks/aws_topology/aws_topology.py
+++ b/aws_topology/stackstate_checks/aws_topology/aws_topology.py
@@ -312,7 +312,7 @@ class AgentProxy(object):
     def create_security_group_relations(self, resource_id, resource_data, security_group_field="SecurityGroups"):
         if resource_data.get(security_group_field):
             for security_group_id in resource_data[security_group_field]:
-                self.relation(resource_id, security_group_id, "uses service", {})
+                self.relation(resource_id, security_group_id, "uses-service", {})
 
 
 class AwsClient:

--- a/aws_topology/stackstate_checks/aws_topology/resources/api_gateway.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/api_gateway.py
@@ -145,7 +145,7 @@ class ApigatewayStageCollector(RegisteredResourceCollector):
                 integration_arn = method_integration_uri[
                     method_integration_uri.rfind("arn") : method_integration_uri.find("/invocations")
                 ]
-                self.emit_relation(method_arn, integration_arn, "uses service", {})
+                self.emit_relation(method_arn, integration_arn, "uses-service", {})
             elif re.match("arn:aws:apigateway:.+:sqs:path/.+", method_integration_uri):
                 queue_arn = arn(
                     resource="sqs",
@@ -153,7 +153,7 @@ class ApigatewayStageCollector(RegisteredResourceCollector):
                     account_id=method_integration_uri.split("/", 2)[1],
                     resource_id=method_integration_uri.rsplit("/", 1)[-1],
                 )
-                self.emit_relation(method_arn, queue_arn, "uses service", {})
+                self.emit_relation(method_arn, queue_arn, "uses-service", {})
 
             # Creates a dummy service component that is connected to the api gateway method
             # this dummy service component will merge with a real trace service
@@ -161,10 +161,10 @@ class ApigatewayStageCollector(RegisteredResourceCollector):
                 parsed_uri = urlparse(method.methodIntegration.uri)
                 service_integration_urn = "urn:service:/{0}".format(parsed_uri.hostname)
                 self.emit_component(service_integration_urn, "aws.apigateway.method.http.integration", {})
-                self.emit_relation(method_arn, service_integration_urn, "uses service", {})
+                self.emit_relation(method_arn, service_integration_urn, "uses-service", {})
 
             self.emit_component(method_arn, ".".join([self.COMPONENT_TYPE, "method"]), method_data)
-            self.emit_relation(resource_arn, method_arn, "uses service", {})
+            self.emit_relation(resource_arn, method_arn, "uses-service", {})
 
     @transformation()
     def process_resource(self, data, stage, api, stage_arn):
@@ -190,7 +190,7 @@ class ApigatewayStageCollector(RegisteredResourceCollector):
                 )
             )
             self.emit_component(resource_arn, ".".join([self.COMPONENT_TYPE, "resource"]), resource_data)
-            self.emit_relation(stage_arn, resource_arn, "uses service", {})
+            self.emit_relation(stage_arn, resource_arn, "uses-service", {})
 
             for method_id in resource.resourceMethods.keys():
                 self.process_resource_method(

--- a/aws_topology/stackstate_checks/aws_topology/resources/api_gateway.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/api_gateway.py
@@ -235,7 +235,7 @@ class ApigatewayStageCollector(RegisteredResourceCollector):
             output["Tags"] = stage.tags
 
         self.emit_component(stage_arn, ".".join([self.COMPONENT_TYPE, "stage"]), output)
-        self.emit_relation(rest_api_arn, stage_arn, "has resource", {})
+        self.emit_relation(rest_api_arn, stage_arn, "has-resource", {})
 
         for resource in resources:
             self.process_resource(resource, stage=stage, api=api, stage_arn=stage_arn)

--- a/aws_topology/stackstate_checks/aws_topology/resources/autoscaling.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/autoscaling.py
@@ -72,13 +72,13 @@ class AutoscalingCollector(RegisteredResourceCollector):
         self.emit_component(auto_scaling_group.AutoScalingGroupName, ".".join([self.COMPONENT_TYPE, "group"]), output)
 
         for instance in auto_scaling_group.Instances:
-            self.emit_relation(auto_scaling_group.AutoScalingGroupARN, instance.InstanceId, "uses service", {})
+            self.emit_relation(auto_scaling_group.AutoScalingGroupARN, instance.InstanceId, "uses-service", {})
 
         for load_balancer_name in auto_scaling_group.LoadBalancerNames:
             elb_arn = self.agent.create_arn(
                 "AWS::ElasticLoadBalancing::LoadBalancer", self.location_info, resource_id=load_balancer_name
             )
-            self.emit_relation(elb_arn, auto_scaling_group.AutoScalingGroupARN, "uses service", {})
+            self.emit_relation(elb_arn, auto_scaling_group.AutoScalingGroupARN, "uses-service", {})
 
             for instance in auto_scaling_group.Instances:
                 # removing elb instances if there are any
@@ -86,7 +86,7 @@ class AutoscalingCollector(RegisteredResourceCollector):
                 self.agent.delete(relation_id)
 
         for target_group_arn in auto_scaling_group.TargetGroupARNs:
-            self.emit_relation(target_group_arn, auto_scaling_group.AutoScalingGroupARN, "uses service", {})
+            self.emit_relation(target_group_arn, auto_scaling_group.AutoScalingGroupARN, "uses-service", {})
 
             for instance in auto_scaling_group.Instances:
                 # removing elb instances if there are any

--- a/aws_topology/stackstate_checks/aws_topology/resources/cloudformation.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/cloudformation.py
@@ -126,7 +126,7 @@ class CloudformationCollector(RegisteredResourceCollector):
             resource_arn = self.agent.create_arn(
                 resource.ResourceType, self.location_info, resource.PhysicalResourceId
             )
-            self.emit_relation(stack_id, resource_arn, "has resource", {})
+            self.emit_relation(stack_id, resource_arn, "has-resource", {})
 
     @transformation()
     def process_stack(self, data):

--- a/aws_topology/stackstate_checks/aws_topology/resources/dynamodb.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/dynamodb.py
@@ -111,7 +111,7 @@ class DynamodbTableCollector(RegisteredResourceCollector):
                 )
             )
             self.emit_component(latest_stream_arn, "aws.dynamodb.streams", stream)
-            self.emit_relation(table_arn, latest_stream_arn, "uses service", {})
+            self.emit_relation(table_arn, latest_stream_arn, "uses-service", {})
         return {table_name: table_arn}
 
     def process_resource(self, arn):

--- a/aws_topology/stackstate_checks/aws_topology/resources/ec2.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/ec2.py
@@ -241,7 +241,7 @@ class Ec2InstanceCollector(RegisteredResourceCollector):
             )
         ]
         if security_group.VpcId:  # pragma: no cover
-            self.emit_relation(security_group.VpcId, security_group.GroupId, "has resource", {})
+            self.emit_relation(security_group.VpcId, security_group.GroupId, "has-resource", {})
 
         self.emit_component(security_group.GroupId, "aws.security-group", output)
 

--- a/aws_topology/stackstate_checks/aws_topology/resources/ec2.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/ec2.py
@@ -206,12 +206,12 @@ class Ec2InstanceCollector(RegisteredResourceCollector):
 
         # Map the subnet and if not available then map the VPC
         if instance.SubnetId:
-            self.emit_relation(instance.InstanceId, instance.SubnetId, "uses service", {})
+            self.emit_relation(instance.InstanceId, instance.SubnetId, "uses-service", {})
         elif instance.VpcId:  # pragma: no cover
-            self.emit_relation(instance.InstanceId, instance.VpcId, "uses service", {})
+            self.emit_relation(instance.InstanceId, instance.VpcId, "uses-service", {})
 
         for security_group in instance.SecurityGroups:
-            self.emit_relation(instance.InstanceId, security_group.GroupId, "uses service", {})
+            self.emit_relation(instance.InstanceId, security_group.GroupId, "uses-service", {})
 
         self.emit_component(instance.InstanceId, ".".join([self.COMPONENT_TYPE, "instance"]), output)
 
@@ -308,7 +308,7 @@ class Ec2InstanceCollector(RegisteredResourceCollector):
             )
         ]
         self.emit_component(subnet.SubnetId, "aws.subnet", output)
-        self.emit_relation(subnet.SubnetId, subnet.VpcId, "uses service", {})
+        self.emit_relation(subnet.SubnetId, subnet.VpcId, "uses-service", {})
 
     def collect_vpn_gateways(self):
         for vpn_gateway in client_array_operation(
@@ -333,7 +333,7 @@ class Ec2InstanceCollector(RegisteredResourceCollector):
         self.emit_component(vpn_gateway.VpnGatewayId, "aws.vpngateway", output)
         for vpn_attachment in vpn_gateway.VpcAttachments:
             if vpn_attachment.State == "attached":
-                self.emit_relation(vpn_gateway.VpnGatewayId, vpn_attachment.VpcId, "uses service", {})
+                self.emit_relation(vpn_gateway.VpnGatewayId, vpn_attachment.VpcId, "uses-service", {})
 
     @transformation()
     def process_batch_instances(self, event, seen):

--- a/aws_topology/stackstate_checks/aws_topology/resources/ecs.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/ecs.py
@@ -245,7 +245,7 @@ class EcsCollector(RegisteredResourceCollector):
     def process_container_instance(self, cluster, data):
         container_instance = ContainerInstance(data, strict=False)
         container_instance.validate()
-        self.emit_relation(cluster.clusterArn, container_instance.ec2InstanceId, "uses_ec2_host", {})
+        self.emit_relation(cluster.clusterArn, container_instance.ec2InstanceId, "uses-ec2-host", {})
 
     @transformation()
     def process_cluster(self, data):

--- a/aws_topology/stackstate_checks/aws_topology/resources/ecs.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/ecs.py
@@ -221,7 +221,7 @@ class EcsCollector(RegisteredResourceCollector):
 
         for lb in service.loadBalancers:
             if lb.targetGroupArn:
-                self.emit_relation(service_arn, lb.targetGroupArn, "uses service", {})
+                self.emit_relation(service_arn, lb.targetGroupArn, "uses-service", {})
 
         # remove events because they do not belong to a component
         output.pop("events", None)

--- a/aws_topology/stackstate_checks/aws_topology/resources/elb_classic.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/elb_classic.py
@@ -105,11 +105,11 @@ class ELBClassicCollector(RegisteredResourceCollector):
         output["Tags"] = data.tags
         output["URN"] = [elb_arn]
         self.emit_component(elb_arn, ".".join([self.COMPONENT_TYPE, "load-balancer"]), output)
-        self.emit_relation(elb_arn, elb.VPCId, "uses service", {})
+        self.emit_relation(elb_arn, elb.VPCId, "uses-service", {})
 
         for instance in output.get("Instances", []):
             instance_external_id = instance.get("InstanceId")  # ec2 instance
-            self.emit_relation(elb_arn, instance_external_id, "uses service", {})
+            self.emit_relation(elb_arn, instance_external_id, "uses-service", {})
 
         for instance_health in data.instance_health:
             health = InstanceHealth(instance_health, strict=False)

--- a/aws_topology/stackstate_checks/aws_topology/resources/elb_v2.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/elb_v2.py
@@ -134,7 +134,7 @@ class ElbV2Collector(RegisteredResourceCollector):
         create_security_group_relations(load_balancer.LoadBalancerArn, output, self.agent)
         load_balancer_type = "aws.elb_v2_" + load_balancer.Type.lower()
         self.emit_component(load_balancer.LoadBalancerArn, load_balancer_type, output)
-        self.emit_relation(load_balancer.LoadBalancerArn, load_balancer.VpcId, "uses service", {})
+        self.emit_relation(load_balancer.LoadBalancerArn, load_balancer.VpcId, "uses-service", {})
         return {load_balancer.LoadBalancerArn: load_balancer.Type.lower()}
 
     def process_one_load_balancer(self, arn):
@@ -207,7 +207,7 @@ class ElbV2Collector(RegisteredResourceCollector):
 
         # relation between target group and target
         self.emit_relation(
-            target_group.TargetGroupArn, "urn:aws/target-group-instance/" + target_health.Target.Id, "uses service", {}
+            target_group.TargetGroupArn, "urn:aws/target-group-instance/" + target_health.Target.Id, "uses-service", {}
         )
 
         self.agent.event(
@@ -258,11 +258,11 @@ class ElbV2Collector(RegisteredResourceCollector):
                     )
 
         self.emit_component(target_group.TargetGroupArn, "aws.elb_v2_target_group", output)
-        self.emit_relation(target_group.TargetGroupArn, target_group.VpcId, "uses service", {})
+        self.emit_relation(target_group.TargetGroupArn, target_group.VpcId, "uses-service", {})
 
         for load_balancer_arn in target_group.LoadBalancerArns:
             self.emit_relation(
-                load_balancer_arn, target_group.TargetGroupArn, "uses service", self.location_info.to_primitive()
+                load_balancer_arn, target_group.TargetGroupArn, "uses-service", self.location_info.to_primitive()
             )
 
         # emit health events for all TargetGroups

--- a/aws_topology/stackstate_checks/aws_topology/resources/firehose.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/firehose.py
@@ -40,7 +40,7 @@ class DeliveryStream(Model):
     DeliveryStreamARN = StringType(required=True)
     DeliveryStreamType = StringType()
     Source = ModelType(DeliveryStreamSource)
-    Destinations = ListType(ModelType(DeliveryStreamDestinations, default=[]))
+    Destinations = ListType(ModelType(DeliveryStreamDestinations), default=[])
 
 
 class FirehoseCollector(RegisteredResourceCollector):
@@ -99,12 +99,12 @@ class FirehoseCollector(RegisteredResourceCollector):
 
         if stream.DeliveryStreamType == "KinesisStreamAsSource" and stream.Source:
             kinesis_stream_arn = stream.Source.KinesisStreamSourceDescription.KinesisStreamARN
-            self.emit_relation(kinesis_stream_arn, delivery_stream_arn, "uses service", {})
+            self.emit_relation(kinesis_stream_arn, delivery_stream_arn, "uses-service", {})
 
         for destination in stream.Destinations:
             if destination.S3DestinationDescription:  # pragma: no cover
                 self.emit_relation(
-                    delivery_stream_arn, destination.S3DestinationDescription.BucketARN, "uses service", {}
+                    delivery_stream_arn, destination.S3DestinationDescription.BucketARN, "uses-service", {}
                 )
         # HasMoreDestinations seen in API response
         # There can also be a relation with a lambda that is uses to transform the data

--- a/aws_topology/stackstate_checks/aws_topology/resources/lambdaf.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/lambdaf.py
@@ -119,7 +119,7 @@ class LambdaCollector(RegisteredResourceCollector):
         if event_source.State == "Enabled":
             output = make_valid_data(data)
             # Swapping source/target: StackState models dependencies, not data flow
-            self.emit_relation(event_source.FunctionArn, event_source.EventSourceArn, "uses service", output)
+            self.emit_relation(event_source.FunctionArn, event_source.EventSourceArn, "uses-service", output)
 
     @transformation()
     def process_function(self, data):
@@ -132,7 +132,7 @@ class LambdaCollector(RegisteredResourceCollector):
         self.emit_component(function_arn, ".".join([self.COMPONENT_TYPE, "function"]), output)
 
         if function.VpcConfig.VpcId:
-            self.emit_relation(function_arn, function.VpcConfig.VpcId, "uses service", {})
+            self.emit_relation(function_arn, function.VpcConfig.VpcId, "uses-service", {})
             self.agent.create_security_group_relations(function_arn, output.get("VpcConfig"), "SecurityGroupIds")
 
         if function.Environment:
@@ -142,7 +142,7 @@ class LambdaCollector(RegisteredResourceCollector):
                     rds_arn = self.agent.create_arn(
                         "AWS::RDS::DBInstance", self.location_info, resource_id=env.split(".", 1)[0]
                     )
-                    self.emit_relation(function_arn, rds_arn, "uses service", {})
+                    self.emit_relation(function_arn, rds_arn, "uses-service", {})
 
         # TODO also emit versions as components and relation to alias / canaries
         # https://stackstate.atlassian.net/browse/STAC-13113
@@ -153,7 +153,7 @@ class LambdaCollector(RegisteredResourceCollector):
             alias_output["Function"] = output
             self.emit_component(alias.AliasArn, ".".join([self.COMPONENT_TYPE, "alias"]), alias_output)
             if function.VpcConfig.VpcId:
-                self.emit_relation(alias.AliasArn, function.VpcConfig.VpcId, "uses service", {})
+                self.emit_relation(alias.AliasArn, function.VpcConfig.VpcId, "uses-service", {})
 
     CLOUDFORMATION_TYPE = "AWS::Lambda::Function"
     EVENT_SOURCE = "lambda.amazonaws.com"

--- a/aws_topology/stackstate_checks/aws_topology/resources/rds.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/rds.py
@@ -107,10 +107,10 @@ class RdsCollector(RegisteredResourceCollector):
         output["URN"] = ["urn:endpoint:/" + instance.Endpoint.Address]
         output.update(with_dimensions([{"key": "DBInstanceIdentifier", "value": instance_id}]))
         self.emit_component(instance_arn, ".".join([self.COMPONENT_TYPE, "instance"]), output)
-        self.emit_relation(instance_arn, instance.DBSubnetGroup.VpcId, "uses service", {})
+        self.emit_relation(instance_arn, instance.DBSubnetGroup.VpcId, "uses-service", {})
         # TODO agent.create_security_group_relations (but needs change?)
         for security_group in instance.VpcSecurityGroups:
-            self.emit_relation(instance_arn, security_group.VpcSecurityGroupId, "uses service", {})
+            self.emit_relation(instance_arn, security_group.VpcSecurityGroupId, "uses-service", {})
 
     @transformation()
     def process_cluster(self, data):

--- a/aws_topology/stackstate_checks/aws_topology/resources/redshift.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/redshift.py
@@ -53,7 +53,7 @@ class RedshiftCollector(RegisteredResourceCollector):
         output["URN"] = [cluster_arn]
         self.emit_component(cluster_arn, ".".join([self.COMPONENT_TYPE, "cluster"]), output)
         if cluster.VpcId:
-            self.emit_relation(cluster_arn, cluster.VpcId, "uses service", {})
+            self.emit_relation(cluster_arn, cluster.VpcId, "uses-service", {})
 
     EVENT_SOURCE = "redshift.amazonaws.com"
     CLOUDTRAIL_EVENTS = [

--- a/aws_topology/stackstate_checks/aws_topology/resources/s3.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/s3.py
@@ -91,7 +91,7 @@ class S3Collector(RegisteredResourceCollector):
             function_arn = bucket_notification.LambdaFunctionArn
             if function_arn:  # pragma: no cover
                 for event in bucket_notification.Events:
-                    self.emit_relation(bucket_arn, function_arn, "uses service", {"event_type": event})
+                    self.emit_relation(bucket_arn, function_arn, "uses-service", {"event_type": event})
 
     EVENT_SOURCE = "s3.amazonaws.com"
     CLOUDTRAIL_EVENTS = [

--- a/aws_topology/stackstate_checks/aws_topology/resources/service_discovery.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/service_discovery.py
@@ -84,10 +84,10 @@ class ServiceDiscoveryCollector(RegisteredResourceCollector):
                 self.location_info.Location.AwsAccount,
                 instance.Attributes["ECS_SERVICE_NAME"],
             )
-            self.emit_relation(service_arn, hosted_zone_id, "uses service", {})
+            self.emit_relation(service_arn, hosted_zone_id, "uses-service", {})
         # Don't make a relation to EC2 if ECS is being used - this could be done directly in ECS
         elif "EC2_INSTANCE_ID" in instance.Attributes:
-            self.emit_relation(instance.Attributes["EC2_INSTANCE_ID"], hosted_zone_id, "uses service", {})
+            self.emit_relation(instance.Attributes["EC2_INSTANCE_ID"], hosted_zone_id, "uses-service", {})
 
     @transformation()
     def process_service(self, data):

--- a/aws_topology/stackstate_checks/aws_topology/resources/sns.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/sns.py
@@ -95,7 +95,7 @@ class SnsCollector(RegisteredResourceCollector):
             subscription.validate()
             if subscription.Protocol in ["lambda", "sqs"]:
                 # TODO subscriptions can be cross region! probably also cross account
-                self.emit_relation(topic_arn, subscription.Endpoint, "uses service", {})
+                self.emit_relation(topic_arn, subscription.Endpoint, "uses-service", {})
 
     EVENT_SOURCE = "sns.amazonaws.com"
     CLOUDTRAIL_EVENTS = [

--- a/aws_topology/stackstate_checks/aws_topology/resources/stepfunction.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/stepfunction.py
@@ -149,7 +149,7 @@ class StepFunctionCollector(RegisteredResourceCollector):
         output["tags"] = data.tags
         self.emit_component(state_machine.stateMachineArn, ".".join([self.COMPONENT_TYPE, "statemachine"]), output)
         if state_machine.roleArn:
-            self.emit_relation(state_machine.stateMachineArn, state_machine.roleArn, "uses service", {})
+            self.emit_relation(state_machine.stateMachineArn, state_machine.roleArn, "uses-service", {})
         self.process_state_machine_relations(state_machine.stateMachineArn, state_machine.definition)
 
     def process_state_machine_relations(self, arn, definition):
@@ -163,12 +163,12 @@ class StepFunctionCollector(RegisteredResourceCollector):
     def process_state(self, sfn_arn, arn, state_name, state, is_start=False):
         state_arn = sfn_arn + ":state/" + state_name
         if is_start:
-            self.emit_relation(arn, state_arn, "uses service", {})  # starts state
+            self.emit_relation(arn, state_arn, "uses-service", {})  # starts state
         state["Name"] = state_name
         next_state = state.get("Next")
         if next_state:
             next_state_arn = sfn_arn + ":state/" + next_state
-            self.emit_relation(state_arn, next_state_arn, "uses service", {})  # can transition to
+            self.emit_relation(state_arn, next_state_arn, "uses-service", {})  # can transition to
         state_type = state.get("Type")
         if state_type == "Choice":
             self.process_choice_state(sfn_arn, state_arn, state.get("Choices"), state.get("Default"))
@@ -184,12 +184,12 @@ class StepFunctionCollector(RegisteredResourceCollector):
         choices = choices or []
         if default_state:
             default_state_arn = sfn_arn + ":state/" + default_state
-            self.emit_relation(state_arn, default_state_arn, "uses service", {})  # can transition to (default)
+            self.emit_relation(state_arn, default_state_arn, "uses-service", {})  # can transition to (default)
         for choice in choices:
             choice_next = choice.get("Next")
             if choice_next:
                 choice_arn = sfn_arn + ":state/" + choice_next
-                self.emit_relation(state_arn, choice_arn, "uses service", {})  # can transition to (choice)
+                self.emit_relation(state_arn, choice_arn, "uses-service", {})  # can transition to (choice)
 
     def process_map_state(self, sfn_arn, state_arn, iterator):
         iterator = iterator or {}
@@ -259,39 +259,39 @@ class StepFunctionCollector(RegisteredResourceCollector):
             state["IntegrationType"] = "lambda"
             fn_arn = self.get_function_reference(parameters.get("FunctionName"))
             if fn_arn:
-                self.emit_relation(state_arn, fn_arn, "uses service", {})
+                self.emit_relation(state_arn, fn_arn, "uses-service", {})
         elif resource.startswith("arn:{}:lambda:".format(partition)):
             state["IntegrationType"] = "lambda"
             fn_arn = self.get_function_reference(resource)
             if fn_arn:
-                self.emit_relation(state_arn, fn_arn, "uses service", {})
+                self.emit_relation(state_arn, fn_arn, "uses-service", {})
         elif resource.startswith("arn:{}:states:::dynamodb:".format(partition)):
             state["IntegrationType"] = "dynamodb"
             table_name = parameters.get("TableName")
             if table_name:
                 operation = resource[len("arn:{}:states:::dynamodb:".format(partition)) :]
                 table_arn = self.agent.create_arn("AWS::DynamoDB::Table", self.location_info, resource_id=table_name)
-                self.emit_relation(state_arn, table_arn, "uses service", {"operation": operation})
+                self.emit_relation(state_arn, table_arn, "uses-service", {"operation": operation})
         elif resource.startswith("arn:{}:states:::states:".format(partition)):
             state["IntegrationType"] = "stepfunctions"
             sfn_arn = parameters.get("StateMachineArn")
             if sfn_arn:
-                self.emit_relation(state_arn, sfn_arn, "uses service", {})  # TODO get the type of action
+                self.emit_relation(state_arn, sfn_arn, "uses-service", {})  # TODO get the type of action
         elif ":activity:" in resource:
             state["IntegrationType"] = "activity"
-            self.emit_relation(state_arn, resource, "uses service", {})
+            self.emit_relation(state_arn, resource, "uses-service", {})
         elif resource.startswith("arn:{}:states:::sns:".format(partition)):
             # TODO TopicArn (to topic) or TargetArn (to platform, no component yet)
             state["IntegrationType"] = "sns"
             topic_arn = parameters.get("TopicArn")
             if topic_arn:
-                self.emit_relation(state_arn, topic_arn, "uses service", {})  # TODO get the type of action
+                self.emit_relation(state_arn, topic_arn, "uses-service", {})  # TODO get the type of action
         elif resource.startswith("arn:{}:states:::sqs:".format(partition)):
             state["IntegrationType"] = "sqs"
             queue_url = parameters.get("QueueUrl")
             if queue_url:
                 queue_arn = self.agent.create_arn("AWS::SQS::Queue", self.location_info, queue_url)
-                self.emit_relation(state_arn, queue_arn, "uses service", {})  # TODO get the type of action
+                self.emit_relation(state_arn, queue_arn, "uses-service", {})  # TODO get the type of action
         elif resource.startswith("arn:{}:states:::ecs:".format(partition)):
             # TODO can be full ARN or family:revision
             # TODO NetworkConfiguration also has connection to securitygroups AND subnets
@@ -299,13 +299,13 @@ class StepFunctionCollector(RegisteredResourceCollector):
             definition_id = parameters.get("TaskDefinition")
             if definition_id:
                 definition_arn = definition_id
-                self.emit_relation(state_arn, definition_arn, "uses service", {})  # TODO get the type of action
+                self.emit_relation(state_arn, definition_arn, "uses-service", {})  # TODO get the type of action
             cluster_id = parameters.get("Cluster")
             if cluster_id:
                 cluster_arn = cluster_id
                 if not cluster_id.startswith("arn:"):
                     cluster_arn = self.agent.create_arn("AWS::ECS::Cluster", self.location_info, cluster_id)
-                self.emit_relation(state_arn, cluster_arn, "uses service", {})
+                self.emit_relation(state_arn, cluster_arn, "uses-service", {})
         elif resource.startswith("arn:{}:states:::apigateway:".format(partition)):
             state["IntegrationType"] = "apigateway"
             api_host = parameters.get("ApiEndpoint")
@@ -319,7 +319,7 @@ class StepFunctionCollector(RegisteredResourceCollector):
                     api_arn = self.agent.create_arn(
                         "AWS::ApiGateway::RestApi", self.location_info, api_id + "/" + api_stage
                     )
-                    self.emit_relation(state_arn, api_arn, "uses service", {})
+                    self.emit_relation(state_arn, api_arn, "uses-service", {})
 
     EVENT_SOURCE = "states.amazonaws.com"
     CLOUDTRAIL_EVENTS = [

--- a/aws_topology/stackstate_checks/aws_topology/resources/utils.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/utils.py
@@ -109,7 +109,7 @@ def replace_stage_variables(string, variables):
 def create_security_group_relations(resource_id, resource_data, agent, security_group_field="SecurityGroups"):
     if resource_data.get(security_group_field):
         for security_group_id in resource_data[security_group_field]:
-            agent.relation(resource_id, security_group_id, "uses service", {})  # TODO
+            agent.relation(resource_id, security_group_id, "uses-service", {})  # TODO
 
 
 def deep_sort_lists(value):

--- a/aws_topology/tests/test_all_apis.py
+++ b/aws_topology/tests/test_all_apis.py
@@ -78,7 +78,7 @@ class TestAllApis(BaseApiTest):
         # total relations should be 14 + 1
         relations = list(
             filter(
-                lambda x: x["type"] == "has resource" and x["source_id"].startswith("arn:aws:cloudformation"),
+                lambda x: x["type"] == "has-resource" and x["source_id"].startswith("arn:aws:cloudformation"),
                 topology[0]["relations"],
             )
         )
@@ -90,61 +90,61 @@ class TestAllApis(BaseApiTest):
             relations,
             source_id,
             "arn:aws:lambda:eu-west-1:731070500579:function:com-stackstate-prod-sam-seed-PutHello-1LUD3ESBOR6EY",
-            "has resource",
+            "has-resource",
         )
         # assert for kinesis stream relation
         top.assert_relation(
-            relations, source_id, "arn:aws:kinesis:eu-west-1:731070500579:stream/stream_1", "has resource"
+            relations, source_id, "arn:aws:kinesis:eu-west-1:731070500579:stream/stream_1", "has-resource"
         )
         # assert for s3 bucket relation
-        top.assert_relation(relations, source_id, "arn:aws:s3:::stackstate.com", "has resource")
+        top.assert_relation(relations, source_id, "arn:aws:s3:::stackstate.com", "has-resource")
         # assert for api_stage relation
-        top.assert_relation(relations, source_id, "arn:aws:execute-api:eu-west-1:731070500579:api_1", "has resource")
+        top.assert_relation(relations, source_id, "arn:aws:execute-api:eu-west-1:731070500579:api_1", "has-resource")
         # assert for loadbalancer relation
         top.assert_relation(
             relations,
             source_id,
             "arn:aws:elasticloadbalancing:eu-west-1:731070500579:loadbalancer/app/myfirstloadbalancer/90dd512583d2d7e9",
-            "has resource",
+            "has-resource",
         )
         # assert for target group relation
         top.assert_relation(
             relations,
             source_id,
             "arn:aws:elasticloadbalancing:eu-west-1:731070500579:targetgroup/myfirsttargetgroup/28ddec997ec55d21",
-            "has resource",
+            "has-resource",
         )
         # assert for autoscaling group relation
         top.assert_relation(
-            relations, source_id, "awseb-e-gwhbyckyjq-stack-AWSEBAutoScalingGroup-35ZMDUKHPCUM", "has resource"
+            relations, source_id, "awseb-e-gwhbyckyjq-stack-AWSEBAutoScalingGroup-35ZMDUKHPCUM", "has-resource"
         )
         # assert for elb classic loadbalancer  relation
         top.assert_relation(
             relations,
             source_id,
             "arn:aws:elasticloadbalancing:eu-west-1:731070500579:loadbalancer/classic-loadbalancer-1",
-            "has resource",
+            "has-resource",
         )
         # assert for rds relation
         top.assert_relation(
-            relations, source_id, "arn:aws:rds:eu-west-1:731070500579:db:productiondatabase", "has resource"
+            relations, source_id, "arn:aws:rds:eu-west-1:731070500579:db:productiondatabase", "has-resource"
         )
         # assert for sns topic relation
-        top.assert_relation(relations, source_id, "arn:aws:sns:eu-west-1:731070500579:my-topic-3", "has resource")
+        top.assert_relation(relations, source_id, "arn:aws:sns:eu-west-1:731070500579:my-topic-3", "has-resource")
         # assert for sqs queue relation
         top.assert_relation(
-            relations, source_id, "arn:aws:sqs:eu-west-1:731070500579:STS_stackpack_test", "has resource"
+            relations, source_id, "arn:aws:sqs:eu-west-1:731070500579:STS_stackpack_test", "has-resource"
         )
         # assert for dynamodb table relation
         top.assert_relation(
-            relations, source_id, "arn:aws:dynamodb:eu-west-1:731070500579:table/table_3", "has resource"
+            relations, source_id, "arn:aws:dynamodb:eu-west-1:731070500579:table/table_3", "has-resource"
         )
         # assert for ecs cluster relation
         top.assert_relation(
-            relations, source_id, "arn:aws:ecs:eu-west-1:731070500579:cluster/StackState-ECS-Cluster", "has resource"
+            relations, source_id, "arn:aws:ecs:eu-west-1:731070500579:cluster/StackState-ECS-Cluster", "has-resource"
         )
         # assert for ec2 instance relation
-        top.assert_relation(relations, source_id, "i-1234567890123456", "has resource")
+        top.assert_relation(relations, source_id, "i-1234567890123456", "has-resource")
 
         # assert for cloudformation nested stack
         top.assert_relation(
@@ -152,7 +152,7 @@ class TestAllApis(BaseApiTest):
             "arn:aws:cloudformation:eu-west-1:731070500579:stack/stackstate-topo-cwevents/"
             + "077bd960-9919-11e9-adb7-02135cc8443e",
             source_id,
-            "has resource",
+            "has-resource",
         )
 
         top.assert_all_checked(components, relations, unchecked_components=133)

--- a/aws_topology/tests/test_apigateway.py
+++ b/aws_topology/tests/test_apigateway.py
@@ -146,48 +146,48 @@ class TestApiGateway(BaseApiTest):
         for n in range(1, 3):
             top.assert_relation(relations, api_arn, stage_arn_prefix.format(n), "has-resource")
 
-            top.assert_relation(relations, stage_arn_prefix.format(n), resource_arn_prefix.format(n), "uses service")
+            top.assert_relation(relations, stage_arn_prefix.format(n), resource_arn_prefix.format(n), "uses-service")
 
             top.assert_relation(
-                relations, resource_arn_prefix.format(n), method_arn_prefix.format(n, "PATCH"), "uses service"
+                relations, resource_arn_prefix.format(n), method_arn_prefix.format(n, "PATCH"), "uses-service"
             )
-            top.assert_relation(relations, method_arn_prefix.format(n, "PATCH"), sqs_arn, "uses service")
+            top.assert_relation(relations, method_arn_prefix.format(n, "PATCH"), sqs_arn, "uses-service")
 
             top.assert_relation(
-                relations, resource_arn_prefix.format(n), method_arn_prefix.format(n, "PUT"), "uses service"
+                relations, resource_arn_prefix.format(n), method_arn_prefix.format(n, "PUT"), "uses-service"
             )
             top.assert_relation(
                 relations,
                 method_arn_prefix.format(n, "PUT"),
                 lambda_arn_prefix.format("PutHello-1LUD3ESBOR6EY"),
-                "uses service",
+                "uses-service",
             )
 
             top.assert_relation(
-                relations, resource_arn_prefix.format(n), method_arn_prefix.format(n, "POST"), "uses service"
+                relations, resource_arn_prefix.format(n), method_arn_prefix.format(n, "POST"), "uses-service"
             )
             top.assert_relation(
-                relations, method_arn_prefix.format(n, "POST"), "urn:service:/84.35.236.89", "uses service"
+                relations, method_arn_prefix.format(n, "POST"), "urn:service:/84.35.236.89", "uses-service"
             )
 
             top.assert_relation(
-                relations, resource_arn_prefix.format(n), method_arn_prefix.format(n, "GET"), "uses service"
+                relations, resource_arn_prefix.format(n), method_arn_prefix.format(n, "GET"), "uses-service"
             )
             top.assert_relation(
                 relations,
                 method_arn_prefix.format(n, "GET"),
                 lambda_arn_prefix.format("GetHello-1CZ5O92284Z69"),
-                "uses service",
+                "uses-service",
             )
 
             top.assert_relation(
-                relations, resource_arn_prefix.format(n), method_arn_prefix.format(n, "DELETE"), "uses service"
+                relations, resource_arn_prefix.format(n), method_arn_prefix.format(n, "DELETE"), "uses-service"
             )
             top.assert_relation(
                 relations,
                 method_arn_prefix.format(n, "DELETE"),
                 lambda_arn_prefix.format("DeleteHello-1LDFJCU54ZL5"),
-                "uses service",
+                "uses-service",
             )
 
         top.assert_all_checked(components, relations, unchecked_components=1)

--- a/aws_topology/tests/test_apigateway.py
+++ b/aws_topology/tests/test_apigateway.py
@@ -144,7 +144,7 @@ class TestApiGateway(BaseApiTest):
         # we have 2 stages
         relations = topology[0]["relations"]
         for n in range(1, 3):
-            top.assert_relation(relations, api_arn, stage_arn_prefix.format(n), "has resource")
+            top.assert_relation(relations, api_arn, stage_arn_prefix.format(n), "has-resource")
 
             top.assert_relation(relations, stage_arn_prefix.format(n), resource_arn_prefix.format(n), "uses service")
 

--- a/aws_topology/tests/test_autoscaling.py
+++ b/aws_topology/tests/test_autoscaling.py
@@ -46,11 +46,11 @@ class TestAutoScaling(BaseApiTest):
             relations,
             "arn:aws:elasticloadbalancing:eu-west-1:731070500579:loadbalancer/awseb-e-g-AWSEBLoa-1WTFTHM4EDGUX",
             group_arn,
-            "uses service",
+            "uses-service",
         )
-        top.assert_relation(relations, group_arn, "i-063c119ff97e71b82", "uses service")
-        top.assert_relation(relations, group_arn, "i-0928b13f776ba8e76", "uses service")
-        top.assert_relation(relations, group_arn, "i-0ed02eb3eab5399fb", "uses service")
+        top.assert_relation(relations, group_arn, "i-063c119ff97e71b82", "uses-service")
+        top.assert_relation(relations, group_arn, "i-0928b13f776ba8e76", "uses-service")
+        top.assert_relation(relations, group_arn, "i-0ed02eb3eab5399fb", "uses-service")
 
         self.assertEqual(len(topology[0]["delete_ids"]), 3)
 

--- a/aws_topology/tests/test_cloudformation.py
+++ b/aws_topology/tests/test_cloudformation.py
@@ -52,6 +52,6 @@ class TestCloudFormation(BaseApiTest):
             checks={"LastUpdatedTime": "2019-06-27T20:20:45.336Z", "StackName": "stackstate-topo-cwevents"},
         )
 
-        top.assert_relation(relations, stack2, stack1, "has resource")
+        top.assert_relation(relations, stack2, stack1, "has-resource")
 
         top.assert_all_checked(components, relations)

--- a/aws_topology/tests/test_dynamodb.py
+++ b/aws_topology/tests/test_dynamodb.py
@@ -52,7 +52,7 @@ class TestDynamoDB(BaseApiTest):
             relations,
             "arn:aws:dynamodb:eu-west-1:731070500579:table/table_1",
             "arn:aws:dynamodb:eu-west-1:731070500579:table/table_1/stream/2018-05-17T08:09:27.110",
-            "uses service",
+            "uses-service",
         )
 
         top.assert_component(components, "arn:aws:dynamodb:eu-west-1:731070500579:table/table_2", "aws.dynamodb.table")

--- a/aws_topology/tests/test_ec2.py
+++ b/aws_topology/tests/test_ec2.py
@@ -56,8 +56,8 @@ class TestEC2(BaseApiTest):
             },
         )
 
-        top.assert_relation(relations, test_instance_id, "subnet-67d82910", "uses service")
-        top.assert_relation(relations, test_instance_id, "sg-41c3cc3b", "uses service")
+        top.assert_relation(relations, test_instance_id, "subnet-67d82910", "uses-service")
+        top.assert_relation(relations, test_instance_id, "sg-41c3cc3b", "uses-service")
 
         # nitro instances
         top.assert_component(
@@ -66,8 +66,8 @@ class TestEC2(BaseApiTest):
             "aws.ec2.instance",
             checks={"InstanceId": "i-1234567890123456", "InstanceType": "m6gd.medium", "IsNitro": True},
         )
-        top.assert_relation(relations, "i-1234567890123456", "vpc-6b25d10e", "uses service")
-        top.assert_relation(relations, "i-1234567890123456", "sg-41c3cc3b", "uses service")
+        top.assert_relation(relations, "i-1234567890123456", "vpc-6b25d10e", "uses-service")
+        top.assert_relation(relations, "i-1234567890123456", "sg-41c3cc3b", "uses-service")
 
         self.assertEqual(len(events), 2)
         self.assertEqual(events[0]["host"], test_instance_id)
@@ -216,8 +216,8 @@ class TestEC2(BaseApiTest):
             checks={"SubnetId": "subnet-12345678", "Name": "subnet-12345678-eu-west-1a"},
         )
 
-        top.assert_relation(relations, "subnet-9e4be5f9", "vpc-6b25d10e", "uses service")
-        top.assert_relation(relations, "subnet-12345678", "vpc-6b25d10e", "uses service")
+        top.assert_relation(relations, "subnet-9e4be5f9", "vpc-6b25d10e", "uses-service")
+        top.assert_relation(relations, "subnet-12345678", "vpc-6b25d10e", "uses-service")
 
         top.assert_all_checked(components, relations)
 
@@ -241,7 +241,7 @@ class TestEC2(BaseApiTest):
             },
         )
         self.assert_location_info(comp)
-        top.assert_relation(relations, "vgw-b8c2fccc", "vpc-6b25d10e", "uses service")
+        top.assert_relation(relations, "vgw-b8c2fccc", "vpc-6b25d10e", "uses-service")
 
         top.assert_all_checked(components, relations)
 

--- a/aws_topology/tests/test_ec2_vpn_gateway.py
+++ b/aws_topology/tests/test_ec2_vpn_gateway.py
@@ -84,7 +84,7 @@ class TestVpnGateway(unittest.TestCase):
         self.assertEqual(len(test_topology["relations"]), 1)
         self.assertEqual(
             test_topology["relations"][0],
-            {"source_id": "vgw-b8c2fccc", "target_id": "vpc-6b25d10e", "type": "uses service", "data": {}},
+            {"source_id": "vgw-b8c2fccc", "target_id": "vpc-6b25d10e", "type": "uses-service", "data": {}},
         )
         self.assert_executed_ok()
 

--- a/aws_topology/tests/test_ecs.py
+++ b/aws_topology/tests/test_ecs.py
@@ -86,11 +86,11 @@ class TestEcs(BaseApiTest):
             relations,
             "arn:aws:ecs:eu-west-1:731070500579:service/sample-app-service",
             "arn:aws:elasticloadbalancing:eu-west-1:731070500579:targetgroup/EC2Co-Defau-7HYSTVRX07KO/a7e4eb718fda7510",
-            "uses service",
+            "uses-service",
         )
         # ECS cluster has an instance
         top.assert_relation(
-            relations, "arn:aws:ecs:eu-west-1:731070500579:cluster/StackState-ECS-Cluster", "string", "uses_ec2_host"
+            relations, "arn:aws:ecs:eu-west-1:731070500579:cluster/StackState-ECS-Cluster", "string", "uses-ec2-host"
         )
         top.assert_all_checked(components, relations)
 

--- a/aws_topology/tests/test_elb.py
+++ b/aws_topology/tests/test_elb.py
@@ -32,25 +32,25 @@ class TestElasticLoadbalancingV2(BaseApiTest):
             relations,
             "arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/classic-loadbalancer-1",
             "vpc-6b25d10e",
-            "uses service",
+            "uses-service",
         )
         top.assert_relation(
             relations,
             "arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/classic-loadbalancer-1",
             "sg-193aec7c",
-            "uses service",
+            "uses-service",
         )
         top.assert_relation(
             relations,
             "arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/classic-loadbalancer-1",
             "i-09388d5bfc0ab9e78",
-            "uses service",
+            "uses-service",
         )
         top.assert_relation(
             relations,
             "arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/classic-loadbalancer-1",
             "i-05b20853cc72c23c4",
-            "uses service",
+            "uses-service",
         )
 
         top.assert_all_checked(components, relations)

--- a/aws_topology/tests/test_elbv2.py
+++ b/aws_topology/tests/test_elbv2.py
@@ -42,33 +42,33 @@ class TestElasticLoadbalancingV2(BaseApiTest):
             relations,
             prefix + "loadbalancer/app/myfirstloadbalancer/90dd512583d2d7e9",
             prefix + "targetgroup/myfirsttargetgroup/28ddec997ec55d21",
-            "uses service",
+            "uses-service",
         )
         # Load Balancer A and Target Group A relationship test
         top.assert_relation(
             relations,
             prefix + "targetgroup/myfirsttargetgroup/28ddec997ec55d21",
             "urn:aws/target-group-instance/" + instance_a,
-            "uses service",
+            "uses-service",
         )
         # Load Balancer B and Target Group B relationship test
         top.assert_relation(
             relations,
             prefix + "targetgroup/myfirsttargetgroup/28ddec997ec55d21",
             "urn:aws/target-group-instance/" + instance_b,
-            "uses service",
+            "uses-service",
         )
         # LoadBalancer <-> SecurityGroup
         top.assert_relation(
-            relations, prefix + "loadbalancer/app/myfirstloadbalancer/90dd512583d2d7e9", "sg-193aec7c", "uses service"
+            relations, prefix + "loadbalancer/app/myfirstloadbalancer/90dd512583d2d7e9", "sg-193aec7c", "uses-service"
         )
         # LoadBalancer <-> Vpc
         top.assert_relation(
-            relations, prefix + "loadbalancer/app/myfirstloadbalancer/90dd512583d2d7e9", "vpc-6b25d10e", "uses service"
+            relations, prefix + "loadbalancer/app/myfirstloadbalancer/90dd512583d2d7e9", "vpc-6b25d10e", "uses-service"
         )
         # TargetGroup <-> Vpc
         top.assert_relation(
-            relations, prefix + "targetgroup/myfirsttargetgroup/28ddec997ec55d21", "vpc-6b25d10e", "uses service"
+            relations, prefix + "targetgroup/myfirsttargetgroup/28ddec997ec55d21", "vpc-6b25d10e", "uses-service"
         )
 
         top.assert_all_checked(components, relations)

--- a/aws_topology/tests/test_firehose.py
+++ b/aws_topology/tests/test_firehose.py
@@ -46,13 +46,13 @@ class TestFirehose(BaseApiTest):
             relations,
             "arn:aws:kinesis:eu-west-1:548105126730:stream/stream_1",
             firehose_arn_prefix + "firehose_1",
-            "uses service",
+            "uses-service",
         )
         top.assert_relation(
-            relations, firehose_arn_prefix + "firehose_1", "arn:aws:s3:::firehose-bucket_1", "uses service"
+            relations, firehose_arn_prefix + "firehose_1", "arn:aws:s3:::firehose-bucket_1", "uses-service"
         )
         top.assert_relation(
-            relations, firehose_arn_prefix + "firehose_2", "arn:aws:s3:::firehose-bucket_2", "uses service"
+            relations, firehose_arn_prefix + "firehose_2", "arn:aws:s3:::firehose-bucket_2", "uses-service"
         )
 
         top.assert_all_checked(components, relations)

--- a/aws_topology/tests/test_lambda.py
+++ b/aws_topology/tests/test_lambda.py
@@ -41,14 +41,14 @@ class TestLambda(BaseApiTest):
         )
         # sts-xray-test-01 has vpcid
         top.assert_relation(
-            relations, "arn:aws:lambda:eu-west-1:731070500579:function:sts-xray-test-01", "vpc-c6d073bf", "uses service"
+            relations, "arn:aws:lambda:eu-west-1:731070500579:function:sts-xray-test-01", "vpc-c6d073bf", "uses-service"
         )
         # alias also has relation with vpcid
         top.assert_relation(
             relations,
             "arn:aws:lambda:eu-west-1:731070500579:function:sts-xray-test-01:old",
             "vpc-c6d073bf",
-            "uses service",
+            "uses-service",
         )
 
         top.assert_component(
@@ -66,19 +66,19 @@ class TestLambda(BaseApiTest):
             relations,
             "arn:aws:lambda:eu-west-1:731070500579:function:sts-xray-test-02",
             "arn:aws:rds:eu-west-1:731070500579:db:sn1e7g5j33vyr4o",
-            "uses service",
+            "uses-service",
         )
         top.assert_relation(
             relations,
             "arn:aws:lambda:eu-west-1:731070500579:function:com-stackstate-prod-PersonIdDynamoDBHandler-6KMIBXKKKCEZ",
             "arn:aws:dynamodb:eu-west-1:731070500579:table/table_1/stream/2018-05-17T08:09:27.110",
-            "uses service",
+            "uses-service",
         )
         top.assert_relation(
             relations,
             "arn:aws:lambda:eu-west-1:731070500579:function:com-stackstate-prod-PersonCreatedKinesisHand-19T8EJADX2DE",
             "arn:aws:kinesis:eu-west-1:731070500579:stream/stream_1",
-            "uses service",
+            "uses-service",
         )
 
         top.assert_all_checked(components, relations)

--- a/aws_topology/tests/test_rds.py
+++ b/aws_topology/tests/test_rds.py
@@ -64,25 +64,25 @@ class TestRds(BaseApiTest):
         )
         # instance-1 <-> vpc
         top.assert_relation(
-            relations, "arn:aws:rds:eu-west-1:731070500579:db:productiondatabase", "vpc-6b25d10e", "uses service"
+            relations, "arn:aws:rds:eu-west-1:731070500579:db:productiondatabase", "vpc-6b25d10e", "uses-service"
         )
         # instance-1 <-> security group
         top.assert_relation(
-            relations, "arn:aws:rds:eu-west-1:731070500579:db:productiondatabase", "sg-053ecf78", "uses service"
+            relations, "arn:aws:rds:eu-west-1:731070500579:db:productiondatabase", "sg-053ecf78", "uses-service"
         )
         # instance-1 <-> vpc
         top.assert_relation(
             relations,
             "arn:aws:rds:eu-west-1:731070500579:db:productiondatabase-eu-west-1c",
             "vpc-6b25d10e",
-            "uses service",
+            "uses-service",
         )
         # instance-1 <-> security group
         top.assert_relation(
             relations,
             "arn:aws:rds:eu-west-1:731070500579:db:productiondatabase-eu-west-1c",
             "sg-053ecf78",
-            "uses service",
+            "uses-service",
         )
 
         top.assert_all_checked(components, relations)

--- a/aws_topology/tests/test_redshift.py
+++ b/aws_topology/tests/test_redshift.py
@@ -35,7 +35,7 @@ class TestRedshift(BaseApiTest):
             relations,
             "arn:aws:redshift:eu-west-1:731070500579:cluster:redshift-cluster-1",
             "vpc-c6d073bf",
-            "uses service",
+            "uses-service",
         )
 
         top.assert_all_checked(components, relations)

--- a/aws_topology/tests/test_s3.py
+++ b/aws_topology/tests/test_s3.py
@@ -48,17 +48,17 @@ class TestS3(BaseApiTest):
             relations,
             "arn:aws:s3:::stackstate.com",
             target_id,
-            "uses service",
+            "uses-service",
             checks={"event_type": "s3:ObjectCreated:*"},
         )
         top.assert_relation(
-            relations, "arn:aws:s3:::binx.io", target_id, "uses service", checks={"event_type": "s3:ObjectRemoved:*"}
+            relations, "arn:aws:s3:::binx.io", target_id, "uses-service", checks={"event_type": "s3:ObjectRemoved:*"}
         )
         top.assert_relation(
             relations,
             "arn:aws:s3:::notags",
             target_id,
-            "uses service",
+            "uses-service",
             checks={
                 "event_type": "s3:ObjectCreated:*"
             }

--- a/aws_topology/tests/test_service_discovery.py
+++ b/aws_topology/tests/test_service_discovery.py
@@ -25,13 +25,13 @@ class TestServiceDiscovery(BaseApiTest):
             relations,
             "arn:aws:ecs:eu-west-1:731070500579:service/sample-app-service",
             "Z08264772EZNA9MYBM2OH",
-            "uses service",
+            "uses-service",
         )
         top.assert_relation(
             relations,
             "i-1234567890123456",
             "Z08264772EZNA9MYBM2OH",
-            "uses service",
+            "uses-service",
         )
 
         top.assert_all_checked(components, relations)

--- a/aws_topology/tests/test_sns.py
+++ b/aws_topology/tests/test_sns.py
@@ -21,31 +21,31 @@ class TestSns(BaseApiTest):
             relations,
             "arn:aws:sns:eu-west-1:731070500579:my-topic-1",
             base_target_id + "TopicHandler-11EWA2GN9YNLL",
-            "uses service",
+            "uses-service",
         )
         top.assert_relation(
             relations,
             "arn:aws:sns:eu-west-1:731070500579:my-topic-2",
             base_target_id + "TopicHandler-21EWA2GN9YNLL",
-            "uses service",
+            "uses-service",
         )
         top.assert_relation(
             relations,
             "arn:aws:sns:eu-west-1:731070500579:my-topic-3",
             base_target_id + "TopicHandler-31EWA2GN9YNLL",
-            "uses service",
+            "uses-service",
         )
         top.assert_relation(
             relations,
             "arn:aws:sns:eu-west-1:731070500579:my-topic-3",
             base_target_id + "TopicHandler-41EWA2GN9YNLL",
-            "uses service",
+            "uses-service",
         )
         top.assert_relation(
             relations,
             "arn:aws:sns:eu-west-1:731070500579:my-topic-3",
             "arn:aws:sqs:eu-west-1:731070500579:STS_stackpack_test",
-            "uses service",
+            "uses-service",
         )
 
         top.assert_component(

--- a/aws_topology/tests/test_stepfunctions.py
+++ b/aws_topology/tests/test_stepfunctions.py
@@ -96,56 +96,56 @@ class TestStepFunctions(BaseApiTest):
         for state_name in state_names:
             top.assert_component(components, sfn_id + ":state/" + state_name, "aws.stepfunction.state")
         # starting state
-        top.assert_relation(relations, sfn_id, sfn_id + ":state/ParallelRun", "uses service")
+        top.assert_relation(relations, sfn_id, sfn_id + ":state/ParallelRun", "uses-service")
         # parallel branch 1
-        top.assert_relation(relations, sfn_id + ":state/ParallelRun", sfn_id + ":state/ECS", "uses service")
+        top.assert_relation(relations, sfn_id + ":state/ParallelRun", sfn_id + ":state/ECS", "uses-service")
         # parallel branch 2
-        top.assert_relation(relations, sfn_id + ":state/ParallelRun", sfn_id + ":state/SNS", "uses service")
+        top.assert_relation(relations, sfn_id + ":state/ParallelRun", sfn_id + ":state/SNS", "uses-service")
         if True:
-            top.assert_relation(relations, sfn_id + ":state/SNS", sfn_id + ":state/SQS", "uses service")
-            top.assert_relation(relations, sfn_id + ":state/SQS", sfn_id + ":state/SQSSecondaryRegion", "uses service")
+            top.assert_relation(relations, sfn_id + ":state/SNS", sfn_id + ":state/SQS", "uses-service")
+            top.assert_relation(relations, sfn_id + ":state/SQS", sfn_id + ":state/SQSSecondaryRegion", "uses-service")
         # parallel branch 3
-        top.assert_relation(relations, sfn_id + ":state/ParallelRun", sfn_id + ":state/Lambda", "uses service")
+        top.assert_relation(relations, sfn_id + ":state/ParallelRun", sfn_id + ":state/Lambda", "uses-service")
         if True:
-            top.assert_relation(relations, sfn_id + ":state/Lambda", sfn_id + ":state/LambdaOldVersion", "uses service")
+            top.assert_relation(relations, sfn_id + ":state/Lambda", sfn_id + ":state/LambdaOldVersion", "uses-service")
             top.assert_relation(
-                relations, sfn_id + ":state/LambdaOldVersion", sfn_id + ":state/DynamoDB", "uses service"
+                relations, sfn_id + ":state/LambdaOldVersion", sfn_id + ":state/DynamoDB", "uses-service"
             )
 
-        top.assert_relation(relations, sfn_id + ":state/ParallelRun", sfn_id + ":state/FakeInput", "uses service")
+        top.assert_relation(relations, sfn_id + ":state/ParallelRun", sfn_id + ":state/FakeInput", "uses-service")
         # iterator
-        top.assert_relation(relations, sfn_id + ":state/FakeInput", sfn_id + ":state/ApiMap", "uses service")
+        top.assert_relation(relations, sfn_id + ":state/FakeInput", sfn_id + ":state/ApiMap", "uses-service")
         if True:
-            top.assert_relation(relations, sfn_id + ":state/ApiMap", sfn_id + ":state/ApiGateway", "uses service")
+            top.assert_relation(relations, sfn_id + ":state/ApiMap", sfn_id + ":state/ApiGateway", "uses-service")
         # choice
-        top.assert_relation(relations, sfn_id + ":state/ApiMap", sfn_id + ":state/FakeChoice", "uses service")
+        top.assert_relation(relations, sfn_id + ":state/ApiMap", sfn_id + ":state/FakeChoice", "uses-service")
         if True:
-            top.assert_relation(relations, sfn_id + ":state/FakeChoice", sfn_id + ":state/Finish", "uses service")
-            top.assert_relation(relations, sfn_id + ":state/FakeChoice", sfn_id + ":state/Activity", "uses service")
+            top.assert_relation(relations, sfn_id + ":state/FakeChoice", sfn_id + ":state/Finish", "uses-service")
+            top.assert_relation(relations, sfn_id + ":state/FakeChoice", sfn_id + ":state/Activity", "uses-service")
         # last
-        top.assert_relation(relations, sfn_id + ":state/Activity", sfn_id + ":state/NoFinish", "uses service")
+        top.assert_relation(relations, sfn_id + ":state/Activity", sfn_id + ":state/NoFinish", "uses-service")
 
         # 15 states
 
-        top.assert_relation(relations, sfn_id + ":state/SNS", get_id("SnsTopic"), "uses service")
-        top.assert_relation(relations, sfn_id + ":state/SQS", get_id("SqsQueue"), "uses service")
+        top.assert_relation(relations, sfn_id + ":state/SNS", get_id("SnsTopic"), "uses-service")
+        top.assert_relation(relations, sfn_id + ":state/SQS", get_id("SqsQueue"), "uses-service")
         top.assert_relation(
             relations,
             sfn_id + ":state/SQSSecondaryRegion",
             get_id("SqsQueue", stack="stackstate-main-account-secondary-region", region="us-east-1"),
-            "uses service",
+            "uses-service",
         )
-        top.assert_relation(relations, sfn_id + ":state/DynamoDB", get_id("DynamoDbTable"), "uses service")
+        top.assert_relation(relations, sfn_id + ":state/DynamoDB", get_id("DynamoDbTable"), "uses-service")
         # TODO ApiGatewayV2 not yet supported (SO RELATION LEFT ALERTER)
         # TODO also verify if this is OK to refer to the API stage here?
         self.assertIn("UNSUPPORTED_ARN-AWS::ApiGatewayV2::", get_id("ApiGatewayApi") + "/test")
         # top.assert_relation(relations, sfn_id + ':state/ApiGateway', get_id('ApiGatewayApi') + '/test')
 
-        top.assert_relation(relations, sfn_id + ":state/Lambda", get_id("LambdaFunction"), "uses service")
-        top.assert_relation(relations, sfn_id + ":state/LambdaOldVersion", get_id("LambdaFunction"), "uses service")
-        top.assert_relation(relations, sfn_id + ":state/ECS", get_id("EcsTaskDefinition"), "uses service")
-        top.assert_relation(relations, sfn_id + ":state/ECS", get_id("EcsCluster"), "uses service")
-        top.assert_relation(relations, sfn_id + ":state/Activity", get_id("StepFunctionsActivity"), "uses service")
+        top.assert_relation(relations, sfn_id + ":state/Lambda", get_id("LambdaFunction"), "uses-service")
+        top.assert_relation(relations, sfn_id + ":state/LambdaOldVersion", get_id("LambdaFunction"), "uses-service")
+        top.assert_relation(relations, sfn_id + ":state/ECS", get_id("EcsTaskDefinition"), "uses-service")
+        top.assert_relation(relations, sfn_id + ":state/ECS", get_id("EcsCluster"), "uses-service")
+        top.assert_relation(relations, sfn_id + ":state/Activity", get_id("StepFunctionsActivity"), "uses-service")
         # TODO IAM not yet supported (SO RELATION LEFT ALERTER)
         self.assertIn("UNSUPPORTED_ARN-AWS::IAM::", get_id("StepFunctionsIamRole"))
         # top.assert_relation(relations, sfn_id, get_id('StepFunctionsIamRole'))
@@ -166,11 +166,11 @@ class TestStepFunctions(BaseApiTest):
             {"StartAt": "B2S1", "States": {"B2S1": {"Next": "B2S2"}, "B2S2": {}}},
         ]
         expected_relations = [
-            {"source_id": "brancharn", "target_id": "root:state/B1S1", "type": "uses service", "data": {}},
-            {"source_id": "brancharn", "target_id": "root:state/B2S1", "type": "uses service", "data": {}},
-            {"source_id": "root:state/B1S1", "target_id": "root:state/B1S2", "type": "uses service", "data": {}},
-            {"source_id": "root:state/B2S1", "target_id": "root:state/B2S2", "type": "uses service", "data": {}},
-            {"source_id": "root:state/B1S2", "target_id": "root:state/B3S1", "type": "uses service", "data": {}},
+            {"source_id": "brancharn", "target_id": "root:state/B1S1", "type": "uses-service", "data": {}},
+            {"source_id": "brancharn", "target_id": "root:state/B2S1", "type": "uses-service", "data": {}},
+            {"source_id": "root:state/B1S1", "target_id": "root:state/B1S2", "type": "uses-service", "data": {}},
+            {"source_id": "root:state/B2S1", "target_id": "root:state/B2S2", "type": "uses-service", "data": {}},
+            {"source_id": "root:state/B1S2", "target_id": "root:state/B3S1", "type": "uses-service", "data": {}},
         ]
         expected_components = [
             {"id": "root:state/B1S1", "type": "aws.stepfunction.state"},


### PR DESCRIPTION
### Step 1: Link to Jira issue
https://stackstate.atlassian.net/browse/STAC-13505

### Step 2: Description of changes
Normalazing relation names so we can remove specific relation templates and use generic relation template and mapper function in AWSv2 STP.

### Step 3: Did you add / update tests for your changes in the right area?
- [x] Unit/Component test
- [ ] Integration test	


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: