### PR TITLE
Fix vsphere tox py3 enviroment error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ coverage.xml
 .pytest_cache/
 .benchmarks/
 stackstate_checks_base/test_data
+stackstate_checks_base/test_data_2
 bin/
 
 # Translations

--- a/vsphere/requirements.in
+++ b/vsphere/requirements.in
@@ -1,1 +1,1 @@
-git+https://github.com/vmware/vsphere-automation-sdk-python.git#egg=vSphere-Automation-SDK
+git+https://github.com/vmware/vsphere-automation-sdk-python.git@4fb7d48#egg=vSphere-Automation-SDK

--- a/vsphere/requirements.in
+++ b/vsphere/requirements.in
@@ -1,2 +1,2 @@
 vsphere-automation-sdk==1.0.0
-setuptools==58.0.1; python_version > '3.0'
+setuptools<58.0.0; python_version > '3.0'

--- a/vsphere/requirements.in
+++ b/vsphere/requirements.in
@@ -1,1 +1,2 @@
 vsphere-automation-sdk==1.0.0
+setuptools<58.0.0

--- a/vsphere/requirements.in
+++ b/vsphere/requirements.in
@@ -1,2 +1,2 @@
 vsphere-automation-sdk==1.0.0
-setuptools<58.0.0
+setuptools==43.0.0

--- a/vsphere/requirements.in
+++ b/vsphere/requirements.in
@@ -1,2 +1,2 @@
 vsphere-automation-sdk==1.0.0
-setuptools==44.1.1
+setuptools==58.0.1; python_version > '3.0'

--- a/vsphere/requirements.in
+++ b/vsphere/requirements.in
@@ -1,1 +1,2 @@
+# When vmware publishes new release with this fixes we'll build it and publish it to artifactory.stackstate.io
 git+https://github.com/vmware/vsphere-automation-sdk-python.git@4fb7d48#egg=vSphere-Automation-SDK

--- a/vsphere/requirements.in
+++ b/vsphere/requirements.in
@@ -1,2 +1,2 @@
 vsphere-automation-sdk==1.0.0
-setuptools==43.0.0
+setuptools==44.1.1

--- a/vsphere/requirements.in
+++ b/vsphere/requirements.in
@@ -1,2 +1,1 @@
-vsphere-automation-sdk==1.0.0
-setuptools<58.0.0; python_version > '3.0'
+git+https://github.com/vmware/vsphere-automation-sdk-python.git#egg=vSphere-Automation-SDK

--- a/vsphere/tox.ini
+++ b/vsphere/tox.ini
@@ -29,8 +29,8 @@ commands = flake8 .
 [testenv:py27]
 platform = linux|win32
 
-; To fix error: build/temp.macosx-11.2-x86_64-2.7/_openssl.c:575:10: fatal error: 'openssl/opensslv.h' file not found
-; Unfortunately openssl that comes with macOS is old, you need to install new openssl with brew:
+; ERROR FIX: build/temp.macosx-11.2-x86_64-2.7/_openssl.c:575:10: fatal error: 'openssl/opensslv.h' file not found
+; Unfortunately openssl that comes with macOS is old, you need to install new openssl (OpenSSL 1.0.1+) with brew:
 ; brew install openssl
 ; If you have openssl installed with brew and its old version do:
 ; brew upgrade openssl

--- a/vsphere/tox.ini
+++ b/vsphere/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py27
 envlist =
-    {py27,py3}
+    {py27,py27-mac,py3}
     flake8
 
 [testenv]
@@ -26,13 +26,21 @@ skip_install = true
 deps = flake8
 commands = flake8 .
 
+[testenv:py27]
+platform = linux|win32
+
 ; To fix error: build/temp.macosx-11.2-x86_64-2.7/_openssl.c:575:10: fatal error: 'openssl/opensslv.h' file not found
-; uncomment this lines on macOS when you first create py27 tox environment
-; comment them afterward, as they will break GitLab pipeline
-;[testenv:py27]
-;setenv =
-;    CPPFLAGS=-I/usr/local/opt/openssl/include
-;    LDFLAGS=-L/usr/local/opt/openssl/lib
+; Unfortunately openssl that comes with macOS is old, you need to install new openssl with brew:
+; brew install openssl
+; If you have openssl installed with brew and its old version do:
+; brew upgrade openssl
+; This environment variables point to it.
+; more info about this issue https://github.com/pyca/cryptography/issues/3489
+[testenv:py27-mac]
+platform = darwin
+setenv =
+    CPPFLAGS=-I/usr/local/opt/openssl/include
+    LDFLAGS=-L/usr/local/opt/openssl/lib
 
 [flake8]
 exclude = .eggs,.tox,build

--- a/vsphere/tox.ini
+++ b/vsphere/tox.ini
@@ -5,7 +5,6 @@ basepython = py27
 envlist =
     {py27,py3}
     flake8
-requires = setuptools < 58.0.0
 
 [testenv]
 pip_version = pip==19.3.1
@@ -26,6 +25,14 @@ commands =
 skip_install = true
 deps = flake8
 commands = flake8 .
+
+; To fix error: build/temp.macosx-11.2-x86_64-2.7/_openssl.c:575:10: fatal error: 'openssl/opensslv.h' file not found
+; uncomment this lines on macOS when you first create py27 tox environment
+; comment them afterward, as they will break GitLab pipeline
+;[testenv:py27]
+;setenv =
+;    CPPFLAGS=-I/usr/local/opt/openssl/include
+;    LDFLAGS=-L/usr/local/opt/openssl/lib
 
 [flake8]
 exclude = .eggs,.tox,build

--- a/vsphere/tox.ini
+++ b/vsphere/tox.ini
@@ -5,6 +5,7 @@ basepython = py27
 envlist =
     {py27,py3}
     flake8
+requires = setuptools < 58.0.0
 
 [testenv]
 pip_version = pip==19.3.1


### PR DESCRIPTION
### Step 1: Link to Jira issue
https://stackstate.atlassian.net/browse/STAC-14233

### Step 2: Description of changes
We used our prebuild version of `vsphere-automation-sdk` we hosted on Artifactory.

There is a fix for problem with py3 and depricated `2_to_3` call in https://github.com/vmware/vsphere-automation-sdk-python
Now we pull code from original repo directly.

It's pinned to specific commit that fixes our problem.