### PR TITLE
Revert "STAC-14364: Avoid setting a health sync expire default when using the…"

### DIFF
--- a/agent_integration_sample/tests/test_agent_integration_sample.py
+++ b/agent_integration_sample/tests/test_agent_integration_sample.py
@@ -84,7 +84,7 @@ class TestAgentIntegration(unittest.TestCase):
         )
         aggregator.assert_service_check('example.can_connect', self.check.OK)
         health.assert_snapshot(self.check.check_id, self.check.health.stream,
-                               start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15},
+                               start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15},
                                stop_snapshot={},
                                check_states=[{'checkStateId': 'id',
                                               'health': 'CRITICAL',

--- a/dynatrace_health/tests/test_dynatrace_health.py
+++ b/dynatrace_health/tests/test_dynatrace_health.py
@@ -23,7 +23,7 @@ def test_no_events_means_empty_health_snapshot(dynatrace_check, test_instance, r
     aggregator.assert_service_check(dynatrace_check.SERVICE_CHECK_NAME, count=1, status=AgentCheck.OK)
     health.assert_snapshot(dynatrace_check.check_id, dynatrace_check.health.stream,
                            check_states=[],
-                           start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15},
+                           start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15},
                            stop_snapshot={})
     assert len(aggregator.events) == 0
 
@@ -56,7 +56,7 @@ def test_events_process_limit(dynatrace_check, test_instance, aggregator, reques
                                                      'Source: builtin',
                                           'name': 'Dynatrace event',
                                           'topologyElementIdentifier': 'urn:dynatrace:/SERVICE-9B16B9C5B03836C5'}],
-                           start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15},
+                           start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15},
                            stop_snapshot={})
 
 
@@ -87,7 +87,7 @@ def test_events_process_limit_with_batches(dynatrace_check, test_instance, reque
                                           'name': 'Dynatrace event',
                                           'topologyElementIdentifier': 'urn:dynatrace:/SERVICE-FAA29C9BB1C02F9B'}
                                          ],
-                           start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15},
+                           start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15},
                            stop_snapshot={})
 
 
@@ -139,7 +139,7 @@ def test_generated_events(dynatrace_check, test_instance, requests_mock, aggrega
                                                      '1613430060467 Source: builtin',
                                           'name': 'Dynatrace event',
                                           'topologyElementIdentifier': 'urn:dynatrace:/HOST-8F3EDA24EEF51137'}],
-                           start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15},
+                           start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15},
                            stop_snapshot={})
     assert len(telemetry._topology_events) == 1
     expected_topology_events = load_json_from_file('expected_topology_events.json', 'samples')

--- a/dynatrace_topology/tests/test_dynatrace_health.py
+++ b/dynatrace_topology/tests/test_dynatrace_health.py
@@ -22,5 +22,5 @@ def test_health(dynatrace_check, requests_mock, test_instance, aggregator, healt
                                           'message': 'SQL01.stackstate.lab is monitored by Dynatrace',
                                           'name': 'Dynatrace monitored',
                                           'topologyElementIdentifier': 'urn:dynatrace:/HOST-AA6A5D81A0006807'}],
-                           start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15},
+                           start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15},
                            stop_snapshot={})

--- a/nagios/tests/compose/docker-compose.yaml
+++ b/nagios/tests/compose/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   mysql:
-    image: artifactory.stackstate.io/docker-virtual/mysql:5.7
+    image: mysql:5.7
     volumes:
       - ./mysql:/docker-entrypoint-initdb.d
     restart: always

--- a/postgres/tests/compose/docker-compose.yaml
+++ b/postgres/tests/compose/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: "artifactory.stackstate.io/docker-virtual/postgres:${POSTGRES_VERSION}-alpine"
+    image: "postgres:${POSTGRES_VERSION}-alpine"
     ports:
       - 5432:5432
     healthcheck:

--- a/stackstate-changelog.md
+++ b/stackstate-changelog.md
@@ -1,9 +1,5 @@
 # StackState Agent Integrations v2 releases
 
-## 1.17.0 / 2021-??-??
-
-* [Fixed] Dropped default expiry value for health checks when using a main stream as expiry is optional in that case. [(STAC-14364)](https://stackstate.atlassian.net/browse/STAC-14364)
-
 ## 1.16.0 / 2021-10-15
 
 * [Fixed] Fix the type for azureHostNames attribute of Dynatrace component [(STAC-14048)](https://stackstate.atlassian.net/browse/STAC-14048)

--- a/stackstate_checks_base/stackstate_checks/base/checks/base.py
+++ b/stackstate_checks_base/stackstate_checks/base/checks/base.py
@@ -250,13 +250,8 @@ class AgentCheckBase(object):
             min_collection_interval = self.instance.get('min_collection_interval', 15)
             repeat_interval_seconds = stream_spec.repeat_interval_seconds or min_collection_interval
             expiry_seconds = stream_spec.expiry_seconds
-            # Only apply a default expiration when we are using substreams
             if expiry_seconds is None:
-                if stream_spec.sub_stream != "":
-                    expiry_seconds = repeat_interval_seconds * 4
-                else:
-                    # Explicitly disable expiry setting it to 0
-                    expiry_seconds = 0
+                expiry_seconds = repeat_interval_seconds * 4
             self.health = HealthApi(self, stream_spec, expiry_seconds, repeat_interval_seconds)
 
     def _check_run_base(self, default_result):

--- a/stackstate_checks_base/stackstate_checks/base/utils/health_api.py
+++ b/stackstate_checks_base/stackstate_checks/base/utils/health_api.py
@@ -74,9 +74,9 @@ class HealthStream(object):
         :param repeat_interval_seconds: (optional) the interval in which the data will be repeated.
                                         will default to the check instance min_collection_interval
         :param expiry_seconds: (optional) the time after which health check states will be expired.
-                               Providing 0 will disable expiry, which can only be done when no substream is specified
-                               Expiry is mandatory when specifying a substream,
-                               by default will be four times the repeat_interval_seconds
+                               by default will be four times the repeat_interval_seconds.
+                               Providing 0 will disable expiry.
+                               Expiry can only be disabled when no substream is specified
         """
         self.urn = import_converter(ClassType(HealthStreamUrn, required=True), urn, None)
         self.sub_stream = import_converter(StrictStringType(required=True), sub_stream, None)

--- a/stackstate_checks_base/tests/test_agent_check.py
+++ b/stackstate_checks_base/tests/test_agent_check.py
@@ -379,19 +379,6 @@ class HealthCheck(AgentCheck):
         return
 
 
-class HealthCheckMainStream(AgentCheck):
-    def __init__(self, stream=HealthStream(HealthStreamUrn("source", "stream_id")), *args, **kwargs):
-        instances = [{'a': 'b'}]
-        self.stream = stream
-        super(HealthCheckMainStream, self).__init__("test", {}, instances)
-
-    def get_health_stream(self, instance):
-        return self.stream
-
-    def check(self, instance):
-        return
-
-
 TEST_STATE = {
     'string': 'string',
     'int': 1,
@@ -1330,15 +1317,6 @@ class TestHealth:
         health.assert_snapshot(check.check_id,
                                check.get_health_stream(None),
                                start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15},
-                               stop_snapshot=None)
-
-    def test_start_snapshot_main_stream(self, health):
-        check = HealthCheckMainStream()
-        check._init_health_api()
-        check.health.start_snapshot()
-        health.assert_snapshot(check.check_id,
-                               check.get_health_stream(None),
-                               start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15},
                                stop_snapshot=None)
 
     def test_stop_snapshot(self, health):

--- a/stackstate_checks_dev/tests/docker/test_default.yaml
+++ b/stackstate_checks_dev/tests/docker/test_default.yaml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   vault:
-    image: artifactory.stackstate.io/docker-virtual/vault:latest
+    image: vault:latest
     container_name: checksdev_vault
     cap_add:
       - IPC_LOCK

--- a/static_health/tests/test_static_health.py
+++ b/static_health/tests/test_static_health.py
@@ -90,7 +90,7 @@ class TestStaticCSVHealth(unittest.TestCase):
         assert json.loads(self.check.run())[0]['message'] == 'Health CSV file is empty.'
         # Snapshot will be started but not stopped
         health.assert_snapshot(self.check.check_id, self.check.health.stream,
-                               start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15})
+                               start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15})
 
     @mock.patch('codecs.open',
                 side_effect=lambda location, mode, encoding: MockFileReader(location, {
@@ -99,7 +99,7 @@ class TestStaticCSVHealth(unittest.TestCase):
     def test_health_min_values(self, mock):
         assert self.check.run() == ""
         health.assert_snapshot(self.check.check_id, self.check.health.stream,
-                               start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15},
+                               start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15},
                                stop_snapshot={},
                                check_states=[{'checkStateId': '1',
                                               'health': 'CLEAR',
@@ -119,7 +119,7 @@ class TestStaticCSVHealth(unittest.TestCase):
     def test_health_max_values(self, mock):
         assert self.check.run() == ""
         health.assert_snapshot(self.check.check_id, self.check.health.stream,
-                               start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15},
+                               start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15},
                                stop_snapshot={},
                                check_states=[{'checkStateId': '1',
                                               'health': 'CLEAR',
@@ -139,7 +139,7 @@ class TestStaticCSVHealth(unittest.TestCase):
         assert json.loads(self.check.run())[0]['message'] == 'CSV header check_state_id not found in health csv.'
         # Snapshot will be started but not stopped
         health.assert_snapshot(self.check.check_id, self.check.health.stream,
-                               start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15})
+                               start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15})
 
     @mock.patch('codecs.open', side_effect=lambda location, mode, encoding: MockFileReader(location, {
                 'health.csv': ['check_state_id,no_name,health,topology_element_identifier']}))
@@ -147,7 +147,7 @@ class TestStaticCSVHealth(unittest.TestCase):
         assert json.loads(self.check.run())[0]['message'] == 'CSV header name not found in health csv.'
         # Snapshot will be started but not stopped
         health.assert_snapshot(self.check.check_id, self.check.health.stream,
-                               start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15})
+                               start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15})
 
     @mock.patch('codecs.open', side_effect=lambda location, mode, encoding: MockFileReader(location, {
                 'health.csv': ['check_state_id,name,no_health,topology_element_identifier']}))
@@ -155,7 +155,7 @@ class TestStaticCSVHealth(unittest.TestCase):
         assert json.loads(self.check.run())[0]['message'] == 'CSV header health not found in health csv.'
         # Snapshot will be started but not stopped
         health.assert_snapshot(self.check.check_id, self.check.health.stream,
-                               start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15})
+                               start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15})
 
     @mock.patch('codecs.open', side_effect=lambda location, mode, encoding: MockFileReader(location, {
                 'health.csv': ['check_state_id,name,health,no_topology_element_identifier']}))
@@ -164,7 +164,7 @@ class TestStaticCSVHealth(unittest.TestCase):
                'CSV header topology_element_identifier not found in health csv.'
         # Snapshot will be started but not stopped
         health.assert_snapshot(self.check.check_id, self.check.health.stream,
-                               start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15})
+                               start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15})
 
     @mock.patch('codecs.open', side_effect=lambda location, mode, encoding: MockFileReader(location, {
                 'health.csv': ['check_state_id,name,health,topology_element_identifier', '1,name,blaat,id1']}))
@@ -172,14 +172,14 @@ class TestStaticCSVHealth(unittest.TestCase):
         assert json.loads(self.check.run())[0]['message'] == '["Health value must be clear, deviating or critical"]'
         # Snapshot will be started but not stopped
         health.assert_snapshot(self.check.check_id, self.check.health.stream,
-                               start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15})
+                               start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15})
 
     @mock.patch('codecs.open', side_effect=lambda location, mode, encoding: MockFileReader(location, {
                 'health.csv': ['check_state_id,name,health,topology_element_identifier', '1,name1,clear,id1', '']}))
     def test_handle_empty_line(self, mock):
         assert self.check.run() == ""
         health.assert_snapshot(self.check.check_id, self.check.health.stream,
-                               start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15},
+                               start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15},
                                stop_snapshot={},
                                check_states=[{'checkStateId': '1',
                                               'health': 'CLEAR',
@@ -193,7 +193,7 @@ class TestStaticCSVHealth(unittest.TestCase):
     def test_handle_incomplete_line(self, mock):
         assert self.check.run() == ""
         health.assert_snapshot(self.check.check_id, self.check.health.stream,
-                               start_snapshot={'expiry_interval_s': 0, 'repeat_interval_s': 15},
+                               start_snapshot={'expiry_interval_s': 60, 'repeat_interval_s': 15},
                                stop_snapshot={},
                                check_states=[{'checkStateId': '1',
                                               'health': 'CLEAR',


### PR DESCRIPTION
Reverts StackVista/stackstate-agent-integrations#236
We need another fix into 1.16 before this new change.