### PR TITLE
Trying to fix failing win build

### DIFF
--- a/stackstate_checks_dev/setup.py
+++ b/stackstate_checks_dev/setup.py
@@ -80,6 +80,7 @@ setup(
             'in-toto==0.2.3',
             'pip-tools',
             'pylint',
+            'lazy_object_proxy<1.7.0',
             'pyperclip>=1.7.0',
             'PyYAML>=3.13',
             'semver',


### PR DESCRIPTION
Lazy-object-proxy in version 1.7.0 dropped python2 support.

https://pypi.org/project/lazy-object-proxy/