### PR TITLE
vSphere: config.guestId/guestFullName changed to guest.guestId/guestFullName

### DIFF
--- a/vsphere/stackstate_checks/vsphere/vsphere.py
+++ b/vsphere/stackstate_checks/vsphere/vsphere.py
@@ -454,8 +454,8 @@ class VSphereCheck(AgentCheck):
                     property_spec.pathSet.append("runtime.host")
                     property_spec.pathSet.append("guest.hostName")
                     # Topology property collection as we did previously
-                    property_spec.pathSet.append("config.guestId")
-                    property_spec.pathSet.append("config.guestFullName")
+                    property_spec.pathSet.append("guest.guestId")
+                    property_spec.pathSet.append("guest.guestFullName")
                     property_spec.pathSet.append("config.hardware.numCPU")
                     property_spec.pathSet.append("config.hardware.memoryMB")
                     property_spec.pathSet.append("datastore")
@@ -1057,8 +1057,8 @@ class VSphereCheck(AgentCheck):
                         datastores.append(ds._moId)
                     topology_tags["datastore"] = datastores
                     add_label_pair(labels, "name", topology_tags["name"])
-                    add_label_pair(labels, "guestId", properties.get("config.guestId", ""))
-                    add_label_pair(labels, "guestFullName", properties.get("config.guestFullName", ""))
+                    add_label_pair(labels, "guestId", properties.get("guest.guestId", ""))
+                    add_label_pair(labels, "guestFullName", properties.get("guest.guestFullName", ""))
                     add_label_pair(labels, "numCPU", properties.get("config.hardware.numCPU", ""))
                     add_label_pair(labels, "memoryMB", properties.get("config.hardware.memoryMB", ""))
                     topology_tags["labels"] = labels


### PR DESCRIPTION
### Step 1: Link to Jira issue
Jira: N/A
Support case: 1077

### Step 2: Description of changes
Changed extraction of VM's guestId and guestFullName info from config to guest.
config.guestId/config.guestFullName is set in the VMX file
guest.guestId/guest.guestFullName is provided by VMWare Tools. 
guest.guestId/guest.guestFullName is set to config.guestId/config.guestFullName in the case where VMWare Tools is not installed.


### Step 3: Did you add / update tests for your changes in the right area?
- [X] Unit/Component test
- [ ] Integration test	


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: