### PR TITLE
STAC-0: Bump the metric limit for prometheus and open metrics check

### DIFF
--- a/stackstate_checks_base/stackstate_checks/base/checks/openmetrics/base_check.py
+++ b/stackstate_checks_base/stackstate_checks/base/checks/openmetrics/base_check.py
@@ -20,7 +20,7 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
             - bar
             - foo
     """
-    DEFAULT_METRIC_LIMIT = 2000
+    DEFAULT_METRIC_LIMIT = 25000
 
     def __init__(self, name, init_config, agentConfig, instances=None, default_instances=None, default_namespace=None):
         super(OpenMetricsBaseCheck, self).__init__(name, init_config, agentConfig, instances=instances)

--- a/stackstate_checks_base/stackstate_checks/base/checks/prometheus/base_check.py
+++ b/stackstate_checks_base/stackstate_checks/base/checks/prometheus/base_check.py
@@ -84,7 +84,7 @@ class GenericPrometheusCheck(AgentCheck):
             - bar
             - foo
     """
-    DEFAULT_METRIC_LIMIT = 2000
+    DEFAULT_METRIC_LIMIT = 25000
 
     def __init__(self, name, init_config, agentConfig, instances=None, default_instances=None, default_namespace=""):
         super(GenericPrometheusCheck, self).__init__(name, init_config, agentConfig, instances)

--- a/stackstate_checks_base/stackstate_checks/base/checks/prometheus/prometheus_base.py
+++ b/stackstate_checks_base/stackstate_checks/base/checks/prometheus/prometheus_base.py
@@ -23,7 +23,7 @@ from .. import AgentCheck
 
 
 class PrometheusCheck(PrometheusScraperMixin, AgentCheck):
-    DEFAULT_METRIC_LIMIT = 2000
+    DEFAULT_METRIC_LIMIT = 25000
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         super(PrometheusCheck, self).__init__(name, init_config, agentConfig, instances)


### PR DESCRIPTION
### Step 1: Link to Jira issue
NA

### Step 2: Description of changes
The default 2000 time series limit is too restrictive when you are tracking a couple of high cardinality metrics.

### Step 3: Did you add / update tests for your changes in the right area?
- [ ] Unit/Component test
- [ ] Integration test	


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: