### PR TITLE
Update stepfunction.py

### DIFF
--- a/aws_topology/stackstate_checks/aws_topology/resources/stepfunction.py
+++ b/aws_topology/stackstate_checks/aws_topology/resources/stepfunction.py
@@ -75,7 +75,7 @@ class StepFunctionCollector(RegisteredResourceCollector):
 
     @set_required_access_v2("states:DescribeStateMachine")
     def collect_state_machine_description(self, arn):
-        return self.client.describe_state_machine(stateMachineArn=arn)
+        return self.client.describe_state_machine(stateMachineArn=arn, includedData='METADATA_ONLY')
 
     def collect_state_machine(self, summary):
         arn = summary.get("stateMachineArn")
@@ -149,8 +149,6 @@ class StepFunctionCollector(RegisteredResourceCollector):
         # generate component
         state_machine = StepFunction(data.state_machine, strict=False)
         output = make_valid_data(data.state_machine)
-        if "definition" in output:
-            output.pop("definition")
         output["tags"] = data.tags
         output.update(
             with_dimensions(


### PR DESCRIPTION
Explicitly only retrieve METADATA_ONLY

Not setting this value can result in errors if the agent does not have access to the KMS key or the kms:decrypt action, while the description is always discarded.

Instead, we can prevent these errors and remove the need to remove the description.

See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/stepfunctions/client/describe_state_machine.html

### Step 1: Link to Jira issue


### Step 2: Description of changes
Only retrieve METADATA to prevent errors on permissions that are needed to retrieve data that are discarded later on. 

### Step 3: Did you add / update tests for your changes in the right area?
- [ ] Unit/Component test
- [ ] Integration test	


### Step 4: I'm confident that everything is properly tested:
I got a PO / QA Approval by:
- [ ] Name

### Step 5: Can we ship this feature to production?
- [ ] Yes, I'm proud of my work. Ship it! :ship: