### PR TITLE
STAC-23143: let the Splunk integration use multiple adapters for JWT auth

### DIFF
--- a/splunk_base/requirements-dev.txt
+++ b/splunk_base/requirements-dev.txt
@@ -1,1 +1,2 @@
 -e ../stackstate_checks_dev
+requests-mock==1.9.3

--- a/splunk_base/stackstate_checks/splunk/client/msft_jwt_auth.py
+++ b/splunk_base/stackstate_checks/splunk/client/msft_jwt_auth.py
@@ -1,0 +1,118 @@
+import logging
+import os
+from datetime import datetime, timezone
+import jwt
+import requests
+
+
+class MsJWTAuth:
+
+    def __init__(self, verify=False, cert=None, keyfile=None, timeout=None):
+        self.verify = verify
+        self.cert = cert
+        self.keyfile = keyfile
+        self.timeout = timeout
+        self.log = logging.getLogger(__name__)
+        self._token = None
+        self._token_expiry = datetime.min.replace(tzinfo=timezone.utc)
+
+        # --- MS vars prep ---
+        self.MICROSOFT_TENANT_ID = os.getenv("TENANT_ID")
+        self.MICROSOFT_CLIENT_ID = os.getenv("CLIENT_ID")
+        self.MICROSOFT_CLIENT_SECRET = os.getenv("CLIENT_SECRET")
+        self.MICROSOFT_RENEWAL_MINUTES = int(os.getenv("RENEWAL_MINUTES", 10))
+        self.MICROSOFT_SCOPE = os.getenv("SCOPE")
+
+        # Validate required environment variables
+        if not self.MICROSOFT_TENANT_ID:
+            raise ValueError("TENANT_ID environment variable is required")
+        if not self.MICROSOFT_CLIENT_ID:
+            raise ValueError("CLIENT_ID environment variable is required")
+        if not self.MICROSOFT_CLIENT_SECRET:
+            raise ValueError("CLIENT_SECRET environment variable is required")
+        if not self.MICROSOFT_SCOPE:
+            raise ValueError("SCOPE environment variable is required")
+
+    def generate_token(self):
+        self.log.info("Generating new Microsoft token")
+        microsoft_url = f"https://login.microsoftonline.com/{self.MICROSOFT_TENANT_ID}/oauth2/v2.0/token"
+        microsoft_payload = {
+            "grant_type": "client_credentials",
+            "client_id": self.MICROSOFT_CLIENT_ID,
+            "client_secret": self.MICROSOFT_CLIENT_SECRET,
+            "scope": self.MICROSOFT_SCOPE,
+        }
+        microsoft_headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+
+        try:
+            self.log.debug(f"Requesting token from: {microsoft_url}")
+            self.log.debug(f"Client ID: {self.MICROSOFT_CLIENT_ID}")
+            self.log.debug(f"Scope: {self.MICROSOFT_SCOPE}")
+
+            response = requests.post(microsoft_url, data=microsoft_payload, headers=microsoft_headers,
+                                     verify=self.verify,
+                                     cert=(self.cert, self.keyfile) if self.cert else None, timeout=self.timeout)
+            response.raise_for_status()
+
+            response_json = response.json()
+            self._token = response_json.get("access_token")
+
+            if not self._token:
+                raise Exception("No access_token found in response")
+
+            self.log.info("Successfully generated Microsoft token")
+
+        except requests.exceptions.RequestException as e:
+            self.log.error(f"Failed to generate Microsoft token: {e}")
+            if hasattr(e, 'response') and e.response is not None:
+                self.log.error(f"Response status: {e.response.status_code}")
+                self.log.error(f"Response body: {e.response.text}")
+            raise
+        except Exception as e:
+            self.log.error(f"Unexpected error generating Microsoft token: {e}")
+            raise
+
+        # Decode the token to get the expiry time
+        # Signature and audience verification can be enabled through environment variables,
+        # but are disabled by default.
+        verify_signature_str = os.getenv('JWT_VERIFY_SIGNATURE', 'false')
+        verify_signature = verify_signature_str.lower() == 'true'
+
+        verify_audience_str = os.getenv('JWT_VERIFY_AUDIENCE', 'false')
+        verify_audience = verify_audience_str.lower() == 'true'
+
+        try:
+            # Azure AD tokens use RS256 algorithm, not HS512
+            decoded_token = jwt.decode(self._token, options={"verify_signature": verify_signature,
+                                                             "verify_aud": verify_audience},
+                                       algorithms=['RS256'])
+            expiry = decoded_token.get("exp")
+
+            if expiry:
+                self._token_expiry = datetime.fromtimestamp(expiry, timezone.utc)
+            else:
+                self.log.warning("No expiry found in token, setting default expiry")
+                self._token_expiry = datetime.now(timezone.utc)
+        except jwt.InvalidTokenError as e:
+            self.log.error(f"Failed to decode JWT token: {e}")
+            # Fallback: set a default expiry time
+            self._token_expiry = datetime.now(timezone.utc)
+
+    def is_token_expired(self):
+        if not self._token:
+            return True
+
+        current_time = datetime.now(timezone.utc)
+        time_difference = self._token_expiry - current_time
+        expiry_minutes = time_difference.total_seconds() / 60
+        self.log.info(f"Checking if Microsoft token needs renewal. Time left: {expiry_minutes:.2f} minutes")
+
+        if expiry_minutes < self.MICROSOFT_RENEWAL_MINUTES:
+            self.log.info("Token has expired or is nearing expiration. Renewing.")
+            return True
+        else:
+            self.log.info(f"Token is still valid for {expiry_minutes:.2f} minutes.")
+            return False
+

--- a/splunk_base/stackstate_checks/splunk/client/msft_jwt_auth.py
+++ b/splunk_base/stackstate_checks/splunk/client/msft_jwt_auth.py
@@ -95,12 +95,17 @@ class MsJWTAuth:
             else:
                 self.log.warning("No expiry found in token, setting default expiry")
                 self._token_expiry = datetime.now(timezone.utc)
+
+            return self._token
         except jwt.InvalidTokenError as e:
             self.log.error(f"Failed to decode JWT token: {e}")
             # Fallback: set a default expiry time
             self._token_expiry = datetime.now(timezone.utc)
 
-    def is_token_expired(self):
+    def is_token_expired(self, _token, _is_initial_token):
+        return False
+
+    def token_needs_renewal(self, _token, _renewal_days, _is_initial_token):
         if not self._token:
             return True
 

--- a/splunk_base/stackstate_checks/splunk/client/msft_jwt_auth.py
+++ b/splunk_base/stackstate_checks/splunk/client/msft_jwt_auth.py
@@ -115,4 +115,3 @@ class MsJWTAuth:
         else:
             self.log.info(f"Token is still valid for {expiry_minutes:.2f} minutes.")
             return False
-

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -53,7 +53,7 @@ class SplunkClient:
         if os.getenv("MS_JWT_AUTH"):
             self.jwt_adapter = MsJWTAuth()
         else:
-            self.jwt_adapter = SplunkJWTAuth(instance_config, self._current_time, self._do_post)
+            self.jwt_adapter = SplunkJWTAuth(instance_config, self._do_post)
 
     def auth_session(self, committable_state):
         if self.instance_config.auth_type == AuthType.BasicAuth:
@@ -110,14 +110,10 @@ class SplunkClient:
     def _create_auth_token(self, token):
         self.log.debug("Creating a new authentication token")
         self.requests_session.headers.update({'Authorization': "Bearer %s" % token})
-        
+
         new_token = self.jwt_adapter.generate_token()
         self.requests_session.headers.update({'Authorization': "Bearer %s" % new_token})
         return new_token
-
-    def _current_time(self):
-        """ This method is mocked for testing. Do not change its behavior """
-        return datetime.datetime.utcnow()
 
     def saved_searches(self, splunk_app=None):
         """

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 
 import requests
@@ -10,12 +11,13 @@ if PY3:
 else:
     from urllib import urlencode, quote
 
-import jwt
 import datetime
 
 from urllib3.exceptions import InsecureRequestWarning
 from requests.exceptions import HTTPError, ConnectionError, Timeout
 from stackstate_checks.base.errors import CheckException
+from stackstate_checks.splunk.client.splunk_jwt_auth import SplunkJWTAuth
+from stackstate_checks.splunk.client.msft_jwt_auth import MsJWTAuth
 from stackstate_checks.splunk.config import AuthType
 
 urllib3.disable_warnings(InsecureRequestWarning)
@@ -47,6 +49,11 @@ class SplunkClient:
         self.instance_config = instance_config
         self.log = logging.getLogger('%s' % __name__)
         self.requests_session = requests.session()
+        self.jwt_adapter = None
+        if os.getenv("MS_JWT_AUTH"):
+            self.jwt_adapter = MsJWTAuth()
+        else:
+            self.jwt_adapter = SplunkJWTAuth(instance_config, self._current_time, self._do_post)
 
     def auth_session(self, committable_state):
         if self.instance_config.auth_type == AuthType.BasicAuth:
@@ -85,12 +92,16 @@ class SplunkClient:
             # Since this is first time run, pick the token from conf.yaml
             token = self.instance_config.initial_token
             is_initial_token = True
-        if self._is_token_expired(token, is_initial_token):
+
+        if self.jwt_adapter.is_token_expired(token, is_initial_token):
             self.log.debug("Current in use authentication token is expired")
             msg = "Current in use authentication token is expired. Please provide a valid token in the YAML " \
                   "and restart the Agent"
             raise TokenExpiredException(msg)
-        if self._need_renewal(token, is_initial_token):
+        if self.jwt_adapter.token_needs_renewal(
+                token,
+                self.instance_config.renewal_days,
+                is_initial_token):
             self.log.debug("The token needs renewal as token is about to expire or this is initial token")
             token = self._create_auth_token(token)
             committable_state.set_auth_token(token)
@@ -98,59 +109,11 @@ class SplunkClient:
 
     def _create_auth_token(self, token):
         self.log.debug("Creating a new authentication token")
-        token_path = '/services/authorization/tokens?output_mode=json'
-        name = self.instance_config.name
-        audience = self.instance_config.audience
-        expiry_days = self.instance_config.token_expiration_days
-        payload = {'name': name, 'audience': audience, 'expires_on': "+{}d".format(str(expiry_days))}
         self.requests_session.headers.update({'Authorization': "Bearer %s" % token})
-        response = self._do_post(token_path, payload, self.instance_config.default_request_timeout_seconds)
-        response.raise_for_status()
-        response_json = response.json()
-
-        new_token = response_json.get("entry")[0].get("content").get("token")
+        
+        new_token = self.jwt_adapter.generate_token()
+        self.requests_session.headers.update({'Authorization': "Bearer %s" % new_token})
         return new_token
-
-    def _decode_token_util(self, token, is_initial_token):
-        """
-        Method to decode the token and return the number of days token is valid or invalid
-        :param token: the token to decode
-        :param is_initial_token: boolean flag if it is first initial token, default is False
-        :return: days: the number of days between token expiration and current date
-        """
-        current_time = self._current_time()
-        decoded_token = jwt.decode(token, options={"verify_signature": False}, algorithms=['HS512'])
-        expiry_time = decoded_token.get("exp")
-        if expiry_time == 0 and is_initial_token:
-            self.log.warning("Initial token provided in the configuration doesn't have an expiration value.")
-            return 999
-        expiry_date = datetime.datetime.fromtimestamp(expiry_time)
-        days = (expiry_date.date() - current_time.date()).days
-        return days
-
-    def _is_token_expired(self, token, is_initial_token=False):
-        """
-        Method to check if the token is expired or not
-        :param token: the token used for validation
-        :param is_initial_token: boolean flag if it is first initial token, default is False
-        :return: boolean flag if token is valid or not
-        """
-        days = self._decode_token_util(token, is_initial_token)
-        return True if days < 0 else False
-
-    def _need_renewal(self, token, is_initial_token=False):
-        """
-        Method to check if token needs renewal
-        :param token: the previous in memory or initial valid token
-        :param is_initial_token: boolean flag if it is first initial token, default is False
-        :return: boolean flag if token needs renewal
-        """
-        days = self._decode_token_util(token, is_initial_token)
-        renewal_days = self.instance_config.renewal_days
-        if days <= renewal_days or is_initial_token:
-            return True
-        else:
-            return False
 
     def _current_time(self):
         """ This method is mocked for testing. Do not change its behavior """

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -51,7 +51,11 @@ class SplunkClient:
         self.requests_session = requests.session()
         self.jwt_adapter = None
         if os.getenv("MS_JWT_AUTH"):
-            self.jwt_adapter = MsJWTAuth()
+            self.jwt_adapter = MsJWTAuth(
+                    instance_config.verify_ssl_certificate,
+                    instance_config.cert,
+                    instance_config.keyfile,
+                    instance_config.timeout)
         else:
             self.jwt_adapter = SplunkJWTAuth(instance_config, self._do_post)
 

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -52,10 +52,10 @@ class SplunkClient:
         self.jwt_adapter = None
         if os.getenv("MS_JWT_AUTH"):
             self.jwt_adapter = MsJWTAuth(
-                    instance_config.verify_ssl_certificate,
-                    instance_config.cert,
-                    instance_config.keyfile,
-                    instance_config.timeout)
+                instance_config.verify_ssl_certificate,
+                instance_config.cert,
+                instance_config.keyfile,
+                instance_config.timeout)
         else:
             self.jwt_adapter = SplunkJWTAuth(instance_config, self._do_post)
 

--- a/splunk_base/stackstate_checks/splunk/client/splunk_jwt_auth.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_jwt_auth.py
@@ -1,0 +1,42 @@
+class SplunkJWTAuth:
+
+    def __init__(self):
+        return None
+
+    def _current_time(self):
+        """ This method is mocked for testing. Do not change its behavior """
+        return datetime.datetime.utcnow()
+
+    def generate_token(self):
+        self.log.debug("Creating a new authentication token")
+        token_path = '/services/authorization/tokens?output_mode=json'
+        name = self.instance_config.name
+        audience = self.instance_config.audience
+        expiry_days = self.instance_config.token_expiration_days
+        payload = {'name': name, 'audience': audience, 'expires_on': "+{}d".format(str(expiry_days))}
+        self.requests_session.headers.update({'Authorization': "Bearer %s" % token})
+        response = self._do_post(token_path, payload, self.instance_config.default_request_timeout_seconds)
+        response.raise_for_status()
+        response_json = response.json()
+
+        new_token = response_json.get("entry")[0].get("content").get("token")
+        return new_token 
+
+    def is_token_expired(self, token, renewal_days, is_initial_token=False):
+        """
+        Method to check if the token is expired or not.
+        We treat a token needing renewal as an expired one.
+        :param token: the token used for validation
+        :param is_initial_token: boolean flag if it is first initial token, default is False
+        :return: boolean flag if token is valid or not
+        """
+        current_time = self._current_time()
+        decoded_token = jwt.decode(token, options={"verify_signature": False}, algorithms=['HS512'])
+        expiry_time = decoded_token.get("exp")
+        if expiry_time == 0 and is_initial_token:
+            self.log.warning("Initial token provided in the configuration doesn't have an expiration value.")
+            return False
+        expiry_date = datetime.datetime.fromtimestamp(expiry_time)
+        days = (expiry_date.date() - current_time.date()).days
+        days = self._decode_token_util(token, is_initial_token)
+        return True if days < renewal_days or is_initial_token else False

--- a/splunk_base/stackstate_checks/splunk/client/splunk_jwt_auth.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_jwt_auth.py
@@ -4,17 +4,20 @@ from datetime import datetime, timezone
 import jwt
 import requests
 
+
 class SplunkJWTAuth:
 
-    def __init__(self, instance_config, get_current_time, post_fn):
-        # Passing time function from the outside for easier mocking and integration
+    def __init__(self, instance_config, post_fn):
         self.log = logging.getLogger('%s' % __name__)
         self.instance_config = instance_config
-        self._get_current_time = get_current_time
         self._do_post = post_fn
 
+    def _current_time(self):
+        """ This method is mocked for testing. Do not change its behavior """
+        return datetime.utcnow()
+
     def _get_renewal_days(self, token, is_initial_token=False):
-        current_time = self._get_current_time()
+        current_time = self._current_time()
         decoded_token = jwt.decode(token, options={"verify_signature": False}, algorithms=['HS512'])
         expiry_time = decoded_token.get("exp")
         if expiry_time == 0 and is_initial_token:

--- a/splunk_base/stackstate_checks/splunk/client/splunk_jwt_auth.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_jwt_auth.py
@@ -1,11 +1,28 @@
+import logging
+import os
+from datetime import datetime, timezone
+import jwt
+import requests
+
 class SplunkJWTAuth:
 
-    def __init__(self):
-        return None
+    def __init__(self, instance_config, get_current_time, post_fn):
+        # Passing time function from the outside for easier mocking and integration
+        self.log = logging.getLogger('%s' % __name__)
+        self.instance_config = instance_config
+        self._get_current_time = get_current_time
+        self._do_post = post_fn
 
-    def _current_time(self):
-        """ This method is mocked for testing. Do not change its behavior """
-        return datetime.datetime.utcnow()
+    def _get_renewal_days(self, token, is_initial_token=False):
+        current_time = self._get_current_time()
+        decoded_token = jwt.decode(token, options={"verify_signature": False}, algorithms=['HS512'])
+        expiry_time = decoded_token.get("exp")
+        if expiry_time == 0 and is_initial_token:
+            self.log.warning("Initial token provided in the configuration doesn't have an expiration value.")
+            return False
+        expiry_date = datetime.fromtimestamp(expiry_time)
+        days = (expiry_date.date() - current_time.date()).days
+        return days
 
     def generate_token(self):
         self.log.debug("Creating a new authentication token")
@@ -14,29 +31,20 @@ class SplunkJWTAuth:
         audience = self.instance_config.audience
         expiry_days = self.instance_config.token_expiration_days
         payload = {'name': name, 'audience': audience, 'expires_on': "+{}d".format(str(expiry_days))}
-        self.requests_session.headers.update({'Authorization': "Bearer %s" % token})
         response = self._do_post(token_path, payload, self.instance_config.default_request_timeout_seconds)
         response.raise_for_status()
         response_json = response.json()
 
         new_token = response_json.get("entry")[0].get("content").get("token")
-        return new_token 
+        return new_token
 
-    def is_token_expired(self, token, renewal_days, is_initial_token=False):
-        """
-        Method to check if the token is expired or not.
-        We treat a token needing renewal as an expired one.
-        :param token: the token used for validation
-        :param is_initial_token: boolean flag if it is first initial token, default is False
-        :return: boolean flag if token is valid or not
-        """
-        current_time = self._current_time()
-        decoded_token = jwt.decode(token, options={"verify_signature": False}, algorithms=['HS512'])
-        expiry_time = decoded_token.get("exp")
-        if expiry_time == 0 and is_initial_token:
-            self.log.warning("Initial token provided in the configuration doesn't have an expiration value.")
+    def token_needs_renewal(self, token, renewal_days, is_initial_token):
+        days = self._get_renewal_days(token, is_initial_token)
+        if days <= renewal_days or is_initial_token:
+            return True
+        else:
             return False
-        expiry_date = datetime.datetime.fromtimestamp(expiry_time)
-        days = (expiry_date.date() - current_time.date()).days
-        days = self._decode_token_util(token, is_initial_token)
-        return True if days < renewal_days or is_initial_token else False
+
+    def is_token_expired(self, token, is_initial_token=False):
+        days = self._get_renewal_days(token, is_initial_token)
+        return True if days < 0 else False

--- a/splunk_base/stackstate_checks/splunk/config/splunk_instance_config_models.py
+++ b/splunk_base/stackstate_checks/splunk/config/splunk_instance_config_models.py
@@ -56,9 +56,9 @@ class SplunkConfigInstance(ForgivingBaseModel):
     ignore_saved_search_errors: bool = False
     saved_searches: List[SplunkConfigSavedSearchDefault] = []
     verify_ssl_certificate: Optional[bool] = None
-    cert = Optional[str] = None
-    keyfile = Optional[str] = None
-    timeout = int = SPLUNK_TIMEOUT
+    cert: Optional[str] = None
+    keyfile: Optional[str] = None
+    timeout: int = SPLUNK_TIMEOUT
 
 
 class SplunkConfig(ForgivingBaseModel):

--- a/splunk_base/stackstate_checks/splunk/config/splunk_instance_config_models.py
+++ b/splunk_base/stackstate_checks/splunk/config/splunk_instance_config_models.py
@@ -6,6 +6,9 @@ from stackstate_checks.base.utils.validations_utils import ForgivingBaseModel, S
 from typing import List, Optional
 
 
+SPLUNK_TIMEOUT = 10
+
+
 class SplunkConfigSavedSearchDefault(ForgivingBaseModel):
     name: Optional[str] = None
     match: Optional[str] = None
@@ -53,6 +56,9 @@ class SplunkConfigInstance(ForgivingBaseModel):
     ignore_saved_search_errors: bool = False
     saved_searches: List[SplunkConfigSavedSearchDefault] = []
     verify_ssl_certificate: Optional[bool] = None
+    cert = Optional[str] = None
+    keyfile = Optional[str] = None
+    timeout = int = SPLUNK_TIMEOUT
 
 
 class SplunkConfig(ForgivingBaseModel):

--- a/splunk_base/tests/common.py
+++ b/splunk_base/tests/common.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from stackstate_checks.dev import get_docker_hostname
+from stackstate_checks.splunk.config import AuthType
 
 HOST = get_docker_hostname()
 PORT = '8089'
@@ -59,3 +60,24 @@ def empty_instance_jwt(initial_token):
         'saved_searches': [],
         'collection_interval': 15
     }
+
+
+class FakeInstanceConfig(object):
+    def __init__(self):
+        self.base_url = 'http://testhost:8089'
+        self.default_request_timeout_seconds = 10
+        self.verify_ssl_certificate = False
+        self.ignore_saved_search_errors = True
+        self.username = "admin"
+        self.audience = "test"
+        self.name = "admin"
+        self.token_expiration_days = 90
+        self.renewal_days = 10
+        self.initial_token = "asdfg"
+        self.auth_type = AuthType.BasicAuth
+        self.keyfile = ""
+        self.cert = ""
+        self.timeout = 5000
+
+    def get_auth_tuple(self):
+        return ('username', 'password')

--- a/splunk_base/tests/test_splunk_client.py
+++ b/splunk_base/tests/test_splunk_client.py
@@ -194,84 +194,6 @@ class TestSplunkClient(unittest.TestCase):
         # return finalize exception when connection error occurs
         self.assertRaises(FinalizeException, helper.finalize_sid, "admin_comp1", mocked_saved_search())
 
-    @mock.patch('stackstate_checks.splunk.client.splunk_client.jwt.decode',
-                return_value={"exp": 1591797915, "iat": 1584021915, "aud": "stackstate"})
-    def test_decode_token_util(self, mocked_decode_token):
-        """
-        Test token decoding utility
-        """
-        helper = SplunkClient(FakeInstanceConfig())
-        helper._current_time = mock.MagicMock()
-        helper._current_time.return_value = datetime.datetime(2020, 5, 14, 15, 44, 51)
-        days = helper._decode_token_util("test", False)
-        self.assertEqual(days, 27)
-
-    @mock.patch('stackstate_checks.splunk.client.splunk_client.jwt.decode',
-                return_value={"exp": 0, "iat": 1584021915, "aud": "stackstate"})
-    def test_decode_token_util_when_exp_set_never(self, mocked_decode_token):
-        """
-        Should return 999 days if first initial token expiration set to never
-        """
-        helper = SplunkClient(FakeInstanceConfig())
-        helper._current_time = mock.MagicMock()
-        helper._current_time.return_value = datetime.datetime(2020, 5, 14, 15, 44, 51)
-        days = helper._decode_token_util("test", True)
-        self.assertEqual(days, 999)
-
-    @mock.patch('stackstate_checks.splunk.client.splunk_client.jwt.decode',
-                return_value={"exp": 1591797915, "iat": 1584021915, "aud": "stackstate"})
-    def test_is_token_expired_true(self, mocked_decode_token):
-        """
-        Test token validation method for invalid token
-        """
-        helper = SplunkClient(FakeInstanceConfig())
-        helper._current_time = mock.MagicMock()
-        helper._current_time.return_value = datetime.datetime(2020, 6, 20, 15, 44, 51)
-        valid = helper._is_token_expired("test")
-        # Token is expired
-        self.assertTrue(valid)
-        self.assertEqual(valid, True)
-
-    @mock.patch('stackstate_checks.splunk.client.splunk_client.jwt.decode',
-                return_value={"exp": 1591797915, "iat": 1584021915, "aud": "stackstate"})
-    def test_is_token_expired_false(self, mocked_decode_token):
-        """
-        Test token validation method for invalid token
-        """
-        helper = SplunkClient(FakeInstanceConfig())
-        helper._current_time = mock.MagicMock()
-        helper._current_time.return_value = datetime.datetime(2020, 5, 14, 15, 44, 51)
-        valid = helper._is_token_expired("test")
-        # Token is not expired
-        self.assertFalse(valid)
-        self.assertEqual(valid, False)
-
-    @mock.patch('stackstate_checks.splunk.client.splunk_client.jwt.decode',
-                return_value={"exp": 1591797915, "iat": 1584021915, "aud": "stackstate"})
-    def test_need_renewal_true(self, mocked_decode_token):
-        """
-        Test need renewal method when is_initial_token flag is True and should return True
-        """
-        helper = SplunkClient(FakeInstanceConfig())
-        helper._current_time = mock.MagicMock()
-        helper._current_time.return_value = datetime.datetime(2020, 5, 14, 15, 44, 51)
-        valid = helper._need_renewal("test", True)
-        # Need renewal should return True since flag is true
-        self.assertTrue(valid)
-
-    @mock.patch('stackstate_checks.splunk.client.splunk_client.jwt.decode',
-                return_value={"exp": 1591797915, "iat": 1584021915, "aud": "stackstate"})
-    def test_need_renewal_false(self, mocked_decode_token):
-        """
-        Test need renewal method when is_initial_token is false and should return False
-        """
-        helper = SplunkClient(FakeInstanceConfig())
-        helper._current_time = mock.MagicMock()
-        helper._current_time.return_value = datetime.datetime(2020, 5, 14, 15, 44, 51)
-        valid = helper._need_renewal("test")
-        # Need renewal should return True since flag is true
-        self.assertFalse(valid)
-
     @mock.patch('stackstate_checks.splunk.client.splunk_client.SplunkClient._do_post',
                 return_value=FakeResponse(mocked_token_create_response(), headers={}))
     def test_create_auth_token(self, mocked_response):
@@ -294,7 +216,7 @@ class TestSplunkClient(unittest.TestCase):
         # Initial token and new token should differ
         self.assertNotEqual("test", new_token)
 
-    @mock.patch('stackstate_checks.splunk.client.splunk_client.jwt.decode',
+    @mock.patch('stackstate_checks.splunk.client.splunk_jwt_auth.jwt.decode',
                 return_value={"exp": 1591797915, "iat": 1584021915, "aud": "stackstate"})
     def test_token_auth_session(self, mocked_decode_token):
         """
@@ -309,15 +231,15 @@ class TestSplunkClient(unittest.TestCase):
         helper = SplunkClient(config)
         # update headers with memory token
         helper.requests_session.headers.update({'Authorization': "Bearer memorytokenpresent"})
-        helper._current_time = mock.MagicMock()
-        helper._current_time.return_value = datetime.datetime(2020, 5, 14, 15, 44, 51)
+        helper.jwt_adapter._current_time = mock.MagicMock()
+        helper.jwt_adapter._current_time.return_value = datetime.datetime(2020, 5, 14, 15, 44, 51)
         helper.auth_session(status)
 
         # Header should be still with the memory token
         expected_header = helper.requests_session.headers.get("Authorization")
         self.assertEqual(expected_header, "Bearer {}".format("memorytokenpresent"))
 
-    @mock.patch('stackstate_checks.splunk.client.splunk_client.jwt.decode',
+    @mock.patch('stackstate_checks.splunk.client.splunk_jwt_auth.jwt.decode',
                 return_value={"exp": 1591797915, "iat": 1584021915, "aud": "stackstate"})
     @mock.patch('stackstate_checks.splunk.client.splunk_client.SplunkClient._do_post',
                 return_value=FakeResponse(mocked_token_create_response(), headers={}))
@@ -333,8 +255,8 @@ class TestSplunkClient(unittest.TestCase):
 
         helper = SplunkClient(config)
         helper.requests_session.headers.update({'Authorization': "Bearer memorytokenpresent"})
-        helper._current_time = mock.MagicMock()
-        helper._current_time.return_value = datetime.datetime(2020, 5, 14, 15, 44, 51)
+        helper.jwt_adapter._current_time = mock.MagicMock()
+        helper.jwt_adapter._current_time.return_value = datetime.datetime(2020, 5, 14, 15, 44, 51)
         helper._token_auth_session(status)
 
         # Header should be updated with the new token
@@ -343,7 +265,7 @@ class TestSplunkClient(unittest.TestCase):
         # persistence data will have new updated token
         self.assertEqual(status.get_auth_token(), new_token)
 
-    @mock.patch('stackstate_checks.splunk.client.splunk_client.jwt.decode',
+    @mock.patch('stackstate_checks.splunk.client.splunk_jwt_auth.jwt.decode',
                 return_value={"exp": 1591797915, "iat": 1584021915, "aud": "stackstate"})
     @mock.patch('stackstate_checks.splunk.client.splunk_client.SplunkClient._do_post',
                 return_value=FakeResponse(mocked_token_create_response(), headers={}))
@@ -361,8 +283,8 @@ class TestSplunkClient(unittest.TestCase):
 
         helper = SplunkClient(config)
         helper.requests_session.headers.update({'Authorization': "Bearer memorytokenpresent"})
-        helper._current_time = mock.MagicMock()
-        helper._current_time.return_value = datetime.datetime(2020, 6, 5, 15, 44, 51)
+        helper.jwt_adapter._current_time = mock.MagicMock()
+        helper.jwt_adapter._current_time.return_value = datetime.datetime(2020, 6, 5, 15, 44, 51)
         helper.auth_session(status)
 
         # Header should be updated with the new token
@@ -371,7 +293,7 @@ class TestSplunkClient(unittest.TestCase):
         # persistence data will have new token as well
         self.assertEqual(status.get_auth_token(), new_token)
 
-    @mock.patch('stackstate_checks.splunk.client.splunk_client.jwt.decode',
+    @mock.patch('stackstate_checks.splunk.client.splunk_jwt_auth.jwt.decode',
                 return_value={"exp": 1591797915, "iat": 1584021915, "aud": "stackstate"})
     def test_token_auth_session_invalid_initial_token(self, mocked_decode_token):
         """
@@ -394,7 +316,7 @@ class TestSplunkClient(unittest.TestCase):
               "and restart the Agent"
         self.assertTrue(check, msg)
 
-    @mock.patch('stackstate_checks.splunk.client.splunk_client.jwt.decode',
+    @mock.patch('stackstate_checks.splunk.client.splunk_jwt_auth.jwt.decode',
                 return_value={"exp": 1591797915, "iat": 1584021915, "aud": "stackstate"})
     def test_token_auth_session_invalid_memory_token(self, mocked_decode_token):
         """

--- a/splunk_base/tests/test_splunk_client.py
+++ b/splunk_base/tests/test_splunk_client.py
@@ -8,32 +8,20 @@ import mock
 import json
 from requests.exceptions import HTTPError, ConnectionError, Timeout
 from requests import Response
+
+import base64
 import datetime
+import time
+import os
 
 # project
 from stackstate_checks.splunk.client import SplunkClient, FinalizeException, TokenExpiredException
 from stackstate_checks.splunk.config import AuthType, SplunkPersistentState
 
+from common import FakeInstanceConfig
+
 # Mark the entire module as tests of type `unit`
 pytestmark = pytest.mark.unit
-
-
-class FakeInstanceConfig(object):
-    def __init__(self):
-        self.base_url = 'http://testhost:8089'
-        self.default_request_timeout_seconds = 10
-        self.verify_ssl_certificate = False
-        self.ignore_saved_search_errors = True
-        self.username = "admin"
-        self.audience = "test"
-        self.name = "admin"
-        self.token_expiration_days = 90
-        self.renewal_days = 10
-        self.initial_token = "asdfg"
-        self.auth_type = AuthType.BasicAuth
-
-    def get_auth_tuple(self):
-        return ('username', 'password')
 
 
 class FakeResponse(object):

--- a/splunk_base/tests/test_splunk_jwt_msft_adapter.py
+++ b/splunk_base/tests/test_splunk_jwt_msft_adapter.py
@@ -1,0 +1,53 @@
+import pytest
+from requests_mock import Mocker
+
+from unittest.mock import patch
+
+import json
+import base64
+import datetime
+import time
+import os
+
+from stackstate_checks.splunk.client import SplunkClient
+from stackstate_checks.splunk.config import AuthType, SplunkPersistentState
+
+from common import FakeInstanceConfig
+
+# Mark the entire module as tests of type `unit`
+pytestmark = pytest.mark.unit
+
+
+def test_jwt_adapter_msft_client(requests_mock: Mocker):
+    """
+    Test JWT adapter Microsoft AD JWT client
+    """
+    # Create a valid-looking fake JWT for the mock response
+    exp_time = int(time.time()) + 3600
+    header = {"alg": "RS256", "typ": "JWT"}
+    payload = {"exp": exp_time}
+    encoded_header = base64.urlsafe_b64encode(json.dumps(header).encode()).rstrip(b'=').decode()
+    encoded_payload = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b'=').decode()
+    fake_signature = base64.urlsafe_b64encode(b'fakesignature').rstrip(b'=').decode()
+    fake_jwt = f"{encoded_header}.{encoded_payload}.{fake_signature}"
+
+    os.environ["MS_JWT_AUTH"] = "true"
+    os.environ["CLIENT_ID"] = "test"
+    os.environ["CLIENT_SECRET"] = "test"
+    os.environ["SCOPE"] = "test"
+    os.environ["TENANT_ID"] = "test-tenant-id"
+
+    status = SplunkPersistentState({})
+    config = FakeInstanceConfig()
+    config.auth_type = AuthType.TokenAuth
+
+    client = SplunkClient(config)
+    client.requests_session.headers.update({'Authorization': "Bearer memorytokenpresent"})
+
+    requests_mock.post("https://login.microsoftonline.com/test-tenant-id/oauth2/v2.0/token",
+                       json={"access_token": fake_jwt, "expires_in": 3600},
+                       status_code=200)
+
+    with patch.dict(os.environ, {"JWT_AUTH": "true", "CLIENT_ID": "test", "CLIENT_SECRET": "test", "SCOPE": "test"}):
+        client.auth_session(status)
+        assert client.requests_session.headers['Authorization'] == f"Bearer {fake_jwt}"


### PR DESCRIPTION
The Splunk integration could use JWT authentication, but only the one baked into Splunk itself. Since we want it to be portable to new authentication providers, I refactored the existing code into an adapter pattern.