### PR TITLE
STAC-23310: rename MS_JWT_AUTH to SPLUNK_MS_JWT_AUTH in splunk client

### DIFF
--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -50,7 +50,7 @@ class SplunkClient:
         self.log = logging.getLogger('%s' % __name__)
         self.requests_session = requests.session()
         self.jwt_adapter = None
-        if os.getenv("MS_JWT_AUTH"):
+        if os.getenv("SPLUNK_MS_JWT_AUTH"):
             self.jwt_adapter = MsJWTAuth(
                 instance_config.verify_ssl_certificate,
                 instance_config.cert,

--- a/splunk_base/tests/test_splunk_jwt_msft_adapter.py
+++ b/splunk_base/tests/test_splunk_jwt_msft_adapter.py
@@ -31,7 +31,7 @@ def test_jwt_adapter_msft_client(requests_mock: Mocker):
     fake_signature = base64.urlsafe_b64encode(b'fakesignature').rstrip(b'=').decode()
     fake_jwt = f"{encoded_header}.{encoded_payload}.{fake_signature}"
 
-    os.environ["MS_JWT_AUTH"] = "true"
+    os.environ["SPLUNK_MS_JWT_AUTH"] = "true"
     os.environ["CLIENT_ID"] = "test"
     os.environ["CLIENT_SECRET"] = "test"
     os.environ["SCOPE"] = "test"


### PR DESCRIPTION
Since we want some more fine grained control over the configuration of the JWT Auth both for dynatrace and the splunk client, we are going to rename the environment variable.