### PR TITLE
STAC-23320: allow splunk MS JWT client incomplete configurations

### DIFF
--- a/splunk_base/stackstate_checks/splunk/client/msft_jwt_auth.py
+++ b/splunk_base/stackstate_checks/splunk/client/msft_jwt_auth.py
@@ -62,7 +62,9 @@ class MsJWTAuth:
             if not self._token:
                 raise Exception("No access_token found in response")
 
-            self.log.info("Successfully generated Microsoft token")
+            self.log.info("Successfully generated Microsoft token: {}, {}".format(
+                self.MICROSOFT_CLIENT_ID,
+                self.MICROSOFT_SCOPE))
 
         except requests.exceptions.RequestException as e:
             self.log.error(f"Failed to generate Microsoft token: {e}")

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -125,9 +125,9 @@ class SplunkClient:
         :return: list of names of saved searches
         """
         if splunk_app is not None:
-            search_path = '/servicesNS/-/%s/saved/searches?output_mode=json&count=-1' % splunk_app
+            search_path = '/servicesNS/-/%s/saved/searches?output_mode=json&count=0' % splunk_app
         else:
-            search_path = '/services/saved/searches?output_mode=json&count=-1'
+            search_path = '/services/saved/searches?output_mode=json&count=0'
         response = self._do_get(search_path,
                                 self.instance_config.default_request_timeout_seconds,
                                 self.instance_config.verify_ssl_certificate)

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -52,10 +52,10 @@ class SplunkClient:
         self.jwt_adapter = None
         if os.getenv("SPLUNK_MS_JWT_AUTH"):
             self.jwt_adapter = MsJWTAuth(
-                instance_config.verify_ssl_certificate,
-                instance_config.cert,
-                instance_config.keyfile,
-                instance_config.timeout)
+                getattr(instance_config, 'verify_ssl_certificate', None),
+                getattr(instance_config, 'cert', None),
+                getattr(instance_config, 'keyfile', None),
+                getattr(instance_config, 'timeout', None))
         else:
             self.jwt_adapter = SplunkJWTAuth(instance_config, self._do_post)
 

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -129,6 +129,8 @@ class SplunkClient:
         :return: list of names of saved searches
         """
         splunk_ns_user = self._get_splunk_ns_user()
+        self.log.debug("splunk NS user: {}", splunk_ns_user)
+        self.log.debug("splunk namespaced app: {}", splunk_app)
         if splunk_app is not None:
             search_path = '/servicesNS/%s/%s/saved/searches?output_mode=json&count=0' % (splunk_ns_user, splunk_app)
         else:

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -114,13 +114,16 @@ class SplunkClient:
             token = self._create_auth_token(token)
             committable_state.set_auth_token(token)
         self.requests_session.headers.update({'Authorization': "Bearer %s" % token})
+        self.requests_session.headers.update({'x-backend-auth': "Bearer %s" % token})
 
     def _create_auth_token(self, token):
         self.log.debug("Creating a new authentication token")
         self.requests_session.headers.update({'Authorization': "Bearer %s" % token})
+        self.requests_session.headers.update({'x-backend-auth': "Bearer %s" % token})
 
         new_token = self.jwt_adapter.generate_token()
         self.requests_session.headers.update({'Authorization': "Bearer %s" % new_token})
+        self.requests_session.headers.update({'x-backend-auth': "Bearer %s" % new_token})
         return new_token
 
     def _get_saved_search_path(self, splunk_ns_user, splunk_app=None):

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -248,7 +248,14 @@ class SplunkClient:
     def _do_get(self, path, request_timeout_seconds, verify_ssl_certificate):
         url = "%s%s" % (self.instance_config.base_url, path)
         response = self.requests_session.get(url, timeout=request_timeout_seconds, verify=verify_ssl_certificate)
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except HTTPError as error:
+            self.log.warning(
+                "Received response with status {} and body {}".format(
+                    response.status_code,
+                    response.content))
+            raise error
         return response
 
     def _do_post(self, path, payload, request_timeout_seconds, splunk_ignore_saved_search_errors=True):

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -96,9 +96,10 @@ class SplunkClient:
     def _token_auth_session(self, committable_state):
         is_initial_token = False
         token = committable_state.get_auth_token()
+        new_token = ""
         if token is None:
             # Since this is first time run, pick the token from conf.yaml
-            token = self.instance_config.initial_token
+            token = os.getenv("INITIAL_TOKEN", self.instance_config.initial_token)
             is_initial_token = True
 
         if self.jwt_adapter.is_token_expired(token, is_initial_token):
@@ -111,19 +112,20 @@ class SplunkClient:
                 self.instance_config.renewal_days,
                 is_initial_token):
             self.log.debug("The token needs renewal as token is about to expire or this is initial token")
-            token = self._create_auth_token(token)
-            committable_state.set_auth_token(token)
-        self.requests_session.headers.update({'Authorization': "Bearer %s" % token})
+            new_token = self._create_auth_token(token)
+            # Only commit the token 
+            if os.getenv("COMMIT_JWT_TOKEN_STATE", True):
+                committable_state.set_auth_token(new_token)
+        # Update the Authorization header falling back on the original token provided
+        self.requests_session.headers.update({'Authorization': "Bearer %s" % (new_token or token)})
         self.requests_session.headers.update({'x-backend-auth': "Bearer %s" % token})
 
     def _create_auth_token(self, token):
         self.log.debug("Creating a new authentication token")
         self.requests_session.headers.update({'Authorization': "Bearer %s" % token})
-        self.requests_session.headers.update({'x-backend-auth': "Bearer %s" % token})
 
         new_token = self.jwt_adapter.generate_token()
         self.requests_session.headers.update({'Authorization': "Bearer %s" % new_token})
-        self.requests_session.headers.update({'x-backend-auth': "Bearer %s" % new_token})
         return new_token
 
     def _get_saved_search_path(self, splunk_ns_user, splunk_app=None):

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -113,7 +113,8 @@ class SplunkClient:
                 is_initial_token):
             self.log.debug("The token needs renewal as token is about to expire or this is initial token")
             new_token = self._create_auth_token(token)
-            # Only commit the token
+            # Only commit the token if COMMIT_JWT_TOKEN_STATE is set to True.
+            # There are cases of users that do not want the token to be committed to state
             if os.getenv("COMMIT_JWT_TOKEN_STATE", True):
                 committable_state.set_auth_token(new_token)
         # Update the Authorization header falling back on the original token provided

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -126,9 +126,9 @@ class SplunkClient:
     def _get_saved_search_path(self, splunk_ns_user, splunk_app=None):
         computed_splunk_app = splunk_app or os.getenv('DEFAULT_SPLUNK_SAVED_SEARCH_APP')
         if computed_splunk_app is not None:
-            return '/servicesNS/%s/%s/saved/searches?output_mode=json&count=0' % (splunk_ns_user, computed_splunk_app)
+            return '/servicesNS/%s/%s/saved/searches/?output_mode=json&count=-1' % (splunk_ns_user, computed_splunk_app)
         else:
-            return '/services/saved/searches?output_mode=json&count=0'
+            return '/services/saved/searches/?output_mode=json&count=-1'
 
     def saved_searches(self, splunk_app=None):
         """

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -22,8 +22,6 @@ from stackstate_checks.splunk.config import AuthType
 
 urllib3.disable_warnings(InsecureRequestWarning)
 
-DEFAULT_SPLUNK_SAVED_SEARCH_APP = os.getenv("DEFAULT_SPLUNK_SAVED_SEARCHES_APP", None)
-
 
 class FinalizeException(Exception):
     """
@@ -125,7 +123,14 @@ class SplunkClient:
         self.requests_session.headers.update({'Authorization': "Bearer %s" % new_token})
         return new_token
 
-    def saved_searches(self, splunk_app=DEFAULT_SPLUNK_SAVED_SEARCH_APP):
+    def _get_saved_search_path(self, splunk_ns_user, splunk_app=None):
+        computed_splunk_app = splunk_app or os.getenv('DEFAULT_SPLUNK_SAVED_SEARCH_APP')
+        if computed_splunk_app is not None:
+            return '/servicesNS/%s/%s/saved/searches?output_mode=json&count=0' % (splunk_ns_user, computed_splunk_app)
+        else:
+            return '/services/saved/searches?output_mode=json&count=0'
+
+    def saved_searches(self, splunk_app=None):
         """
         Retrieves a list of saved searches from splunk
         :return: list of names of saved searches
@@ -133,10 +138,8 @@ class SplunkClient:
         splunk_ns_user = self._get_splunk_ns_user()
         self.log.info("splunk NS user: {}", splunk_ns_user)
         self.log.info("splunk namespaced app: {}", splunk_app)
-        if splunk_app is not None:
-            search_path = '/servicesNS/%s/%s/saved/searches?output_mode=json&count=0' % (splunk_ns_user, splunk_app)
-        else:
-            search_path = '/services/saved/searches?output_mode=json&count=0'
+        search_path = self._get_saved_search_path(splunk_ns_user, splunk_app)
+
         response = self._do_get(search_path,
                                 self.instance_config.default_request_timeout_seconds,
                                 self.instance_config.verify_ssl_certificate)

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -115,7 +115,7 @@ class SplunkClient:
             new_token = self._create_auth_token(token)
             # Only commit the token if COMMIT_JWT_TOKEN_STATE is set to True.
             # There are cases of users that do not want the token to be committed to state
-            if os.getenv("COMMIT_JWT_TOKEN_STATE", True):
+            if os.getenv("COMMIT_JWT_TOKEN_STATE", "true") == "true":
                 committable_state.set_auth_token(new_token)
         # Update the Authorization header falling back on the original token provided
         self.requests_session.headers.update({'Authorization': "Bearer %s" % (new_token or token)})

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -89,6 +89,10 @@ class SplunkClient:
         session_key = response_json["sessionKey"]
         self.requests_session.headers.update({'Authentication': "Splunk %s" % session_key})
 
+    def _get_splunk_ns_user(self):
+        splunk_ns_user = os.getenv('SPLUNK_NS_USER', '-')
+        return splunk_ns_user
+
     def _token_auth_session(self, committable_state):
         is_initial_token = False
         token = committable_state.get_auth_token()
@@ -124,8 +128,9 @@ class SplunkClient:
         Retrieves a list of saved searches from splunk
         :return: list of names of saved searches
         """
+        splunk_ns_user = self._get_splunk_ns_user()
         if splunk_app is not None:
-            search_path = '/servicesNS/-/%s/saved/searches?output_mode=json&count=0' % splunk_app
+            search_path = '/servicesNS/%s/%s/saved/searches?output_mode=json&count=0' % (splunk_ns_user, splunk_app)
         else:
             search_path = '/services/saved/searches?output_mode=json&count=0'
         response = self._do_get(search_path,
@@ -142,8 +147,10 @@ class SplunkClient:
         :param count: the maximum number of elements expecting to be returned by the API call
         :return: raw json response from splunk
         """
-        search_path = '/servicesNS/-/-/search/jobs/%s/results?output_mode=json&offset=%s&count=%s' % \
-                      (search_id, offset, count)
+        splunk_ns_user = self._get_splunk_ns_user()
+        search_app = getattr(saved_search, 'app', '-')
+        search_path = '/servicesNS/%s/%s/search/jobs/%s/results?output_mode=json&offset=%s&count=%s' % \
+                      (splunk_ns_user, search_app, search_id, offset, count)
 
         response = self._do_get(search_path,
                                 saved_search.request_timeout_seconds,

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -113,7 +113,7 @@ class SplunkClient:
                 is_initial_token):
             self.log.debug("The token needs renewal as token is about to expire or this is initial token")
             new_token = self._create_auth_token(token)
-            # Only commit the token 
+            # Only commit the token
             if os.getenv("COMMIT_JWT_TOKEN_STATE", True):
                 committable_state.set_auth_token(new_token)
         # Update the Authorization header falling back on the original token provided

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -131,8 +131,8 @@ class SplunkClient:
         :return: list of names of saved searches
         """
         splunk_ns_user = self._get_splunk_ns_user()
-        self.log.debug("splunk NS user: {}", splunk_ns_user)
-        self.log.debug("splunk namespaced app: {}", splunk_app)
+        self.log.info("splunk NS user: {}", splunk_ns_user)
+        self.log.info("splunk namespaced app: {}", splunk_app)
         if splunk_app is not None:
             search_path = '/servicesNS/%s/%s/saved/searches?output_mode=json&count=0' % (splunk_ns_user, splunk_app)
         else:

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -90,7 +90,7 @@ class SplunkClient:
         self.requests_session.headers.update({'Authentication': "Splunk %s" % session_key})
 
     def _get_splunk_ns_user(self):
-        splunk_ns_user = os.getenv('SPLUNK_NS_USER', '-')
+        splunk_ns_user = os.getenv("SPLUNK_NS_USER", "-")
         return splunk_ns_user
 
     def _token_auth_session(self, committable_state):
@@ -136,8 +136,8 @@ class SplunkClient:
         :return: list of names of saved searches
         """
         splunk_ns_user = self._get_splunk_ns_user()
-        self.log.info("splunk NS user: {}", splunk_ns_user)
-        self.log.info("splunk namespaced app: {}", splunk_app)
+        self.log.info("splunk NS user: {}".format(splunk_ns_user))
+        self.log.info("splunk namespaced app: {}".format(splunk_app))
         search_path = self._get_saved_search_path(splunk_ns_user, splunk_app)
 
         response = self._do_get(search_path,

--- a/splunk_base/stackstate_checks/splunk/client/splunk_client.py
+++ b/splunk_base/stackstate_checks/splunk/client/splunk_client.py
@@ -22,6 +22,8 @@ from stackstate_checks.splunk.config import AuthType
 
 urllib3.disable_warnings(InsecureRequestWarning)
 
+DEFAULT_SPLUNK_SAVED_SEARCH_APP = os.getenv("DEFAULT_SPLUNK_SAVED_SEARCHES_APP", None)
+
 
 class FinalizeException(Exception):
     """
@@ -123,7 +125,7 @@ class SplunkClient:
         self.requests_session.headers.update({'Authorization': "Bearer %s" % new_token})
         return new_token
 
-    def saved_searches(self, splunk_app=None):
+    def saved_searches(self, splunk_app=DEFAULT_SPLUNK_SAVED_SEARCH_APP):
         """
         Retrieves a list of saved searches from splunk
         :return: list of names of saved searches

--- a/splunk_base/stackstate_checks/splunk/config/splunk_instance_config.py
+++ b/splunk_base/stackstate_checks/splunk/config/splunk_instance_config.py
@@ -70,7 +70,6 @@ instead of username/password on top level')
         self.verify_ssl_certificate = instance.verify_ssl_certificate or self.default_verify_ssl_certificate
         self.cert = instance.cert or ""
         self.keyfile = instance.keyfile or ""
-        self.default_request_timeout_seconds = int(self.get_or_default('default_request_timeout_seconds'))
 
         self.base_url = instance.url
 

--- a/splunk_base/stackstate_checks/splunk/config/splunk_instance_config.py
+++ b/splunk_base/stackstate_checks/splunk/config/splunk_instance_config.py
@@ -68,6 +68,9 @@ instead of username/password on top level')
         self.default_parameters = self.get_or_default('default_parameters')
 
         self.verify_ssl_certificate = instance.verify_ssl_certificate or self.default_verify_ssl_certificate
+        self.cert = instance.cert or ""
+        self.keyfile = instance.keyfile or ""
+        self.default_request_timeout_seconds = int(self.get_or_default('default_request_timeout_seconds'))
 
         self.base_url = instance.url
 

--- a/splunk_base/stackstate_checks/splunk/saved_search_helper/saved_search_helper.py
+++ b/splunk_base/stackstate_checks/splunk/saved_search_helper/saved_search_helper.py
@@ -24,14 +24,11 @@ class SavedSearches(object):
         self.matches = list(filter(lambda ss: ss.match is not None, saved_searches))
 
     def run_saved_searches(self, process_data, service_check, log, persisted_state, update_status=None):
-        try:
-            if self.instance_config.app is not None and self.instance_config.app != "":
-                new_saved_searches = self.splunk_client.saved_searches(self.instance_config.app)
-            else:
-                new_saved_searches = self.splunk_client.saved_searches()
-        except AttributeError:
-            # This happens when the splunk instance config does not contain an app field, so we just do the same as
-            # the else clause
+        app = getattr(self.instance_config, 'app', None)
+
+        if app is not None and app != "":
+            new_saved_searches = self.splunk_client.saved_searches(app)
+        else:
             new_saved_searches = self.splunk_client.saved_searches()
 
         self._update_searches(log, new_saved_searches)

--- a/splunk_base/tests/common.py
+++ b/splunk_base/tests/common.py
@@ -81,3 +81,22 @@ class FakeInstanceConfig(object):
 
     def get_auth_tuple(self):
         return ('username', 'password')
+
+
+class FakePartialInstanceConfig(object):
+    def __init__(self):
+        self.base_url = 'http://testhost:8089'
+        self.default_request_timeout_seconds = 10
+        self.verify_ssl_certificate = False
+        self.ignore_saved_search_errors = True
+        self.username = "admin"
+        self.audience = "test"
+        self.name = "admin"
+        self.token_expiration_days = 90
+        self.renewal_days = 10
+        self.initial_token = "asdfg"
+        self.auth_type = AuthType.BasicAuth
+        self.timeout = 5000
+
+    def get_auth_tuple(self):
+        return ('username', 'password')

--- a/splunk_base/tests/compose/docker-compose.yaml
+++ b/splunk_base/tests/compose/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   splunk:
-    image: "splunk/splunk:latest"
+    image: "registry.tooling.stackstate.io/docker/splunk/splunk:latest"
     environment:
       SPLUNK_START_ARGS: --accept-license
       SPLUNK_PASSWORD: admin12345

--- a/splunk_base/tests/test_integration_splunk_client.py
+++ b/splunk_base/tests/test_integration_splunk_client.py
@@ -35,6 +35,17 @@ def test_splunk_client_auth_basic(test_environment):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("test_environment")
+def test_splunk_client_saved_searches(test_environment):
+    client = SplunkClient(SplunkInstanceConfig(empty_instance, {}, default_settings))
+    response = client.auth_session({})
+    assert response is None
+
+    saved_searches_response = client.saved_searches(None)
+    assert saved_searches_response[0] == 'Bucket Merge Retrieve Conf Settings'
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("test_environment")
 def test_splunk_client_auth_jwt(test_environment):
     config = SplunkInstanceConfig(empty_instance, {}, default_settings)
     client = SplunkClient(config)

--- a/splunk_base/tests/test_splunk_client.py
+++ b/splunk_base/tests/test_splunk_client.py
@@ -328,3 +328,28 @@ class TestSplunkClient(unittest.TestCase):
         msg = "Current in use authentication token is expired. Please provide a valid token in the YAML " \
               "and restart the Agent"
         self.assertTrue(check, msg)
+
+    def test_client_get_saved_search_path(self):
+        """
+        Test token_auth_session to throw TokenExpiredException when memory token is expired
+        """
+        status = SplunkPersistentState({})
+        # load a token in memory for validation
+        status.set_auth_token('memorytokenpresent')
+        config = FakeInstanceConfig()
+        config.auth_type = AuthType.TokenAuth
+        client = SplunkClient(config)
+        client.requests_session.headers.update({'Authorization': "Bearer memorytokenpresent"})
+        client._current_time = mock.MagicMock()
+        client._current_time.return_value = datetime.datetime(2020, 6, 16, 15, 44, 51)
+
+        search_path = client._get_saved_search_path("-")
+        self.assertEqual(search_path, "/services/saved/searches?output_mode=json&count=0")
+
+        search_path = client._get_saved_search_path("nobody", "test_app")
+        self.assertEqual(search_path, "/servicesNS/nobody/test_app/saved/searches?output_mode=json&count=0")
+
+        os.environ['DEFAULT_SPLUNK_SAVED_SEARCH_APP'] = "pasta_carbonara"
+
+        search_path = client._get_saved_search_path("opensuse")
+        self.assertEqual(search_path, "/servicesNS/opensuse/pasta_carbonara/saved/searches?output_mode=json&count=0")

--- a/splunk_base/tests/test_splunk_client.py
+++ b/splunk_base/tests/test_splunk_client.py
@@ -344,12 +344,12 @@ class TestSplunkClient(unittest.TestCase):
         client._current_time.return_value = datetime.datetime(2020, 6, 16, 15, 44, 51)
 
         search_path = client._get_saved_search_path("-")
-        self.assertEqual(search_path, "/services/saved/searches?output_mode=json&count=0")
+        self.assertEqual(search_path, "/services/saved/searches/?output_mode=json&count=-1")
 
         search_path = client._get_saved_search_path("nobody", "test_app")
-        self.assertEqual(search_path, "/servicesNS/nobody/test_app/saved/searches?output_mode=json&count=0")
+        self.assertEqual(search_path, "/servicesNS/nobody/test_app/saved/searches/?output_mode=json&count=-1")
 
         os.environ['DEFAULT_SPLUNK_SAVED_SEARCH_APP'] = "pasta_carbonara"
 
         search_path = client._get_saved_search_path("opensuse")
-        self.assertEqual(search_path, "/servicesNS/opensuse/pasta_carbonara/saved/searches?output_mode=json&count=0")
+        self.assertEqual(search_path, "/servicesNS/opensuse/pasta_carbonara/saved/searches/?output_mode=json&count=-1")

--- a/splunk_base/tests/test_splunk_jwt_msft_adapter.py
+++ b/splunk_base/tests/test_splunk_jwt_msft_adapter.py
@@ -12,7 +12,7 @@ import os
 from stackstate_checks.splunk.client import SplunkClient
 from stackstate_checks.splunk.config import AuthType, SplunkPersistentState
 
-from common import FakeInstanceConfig
+from common import FakeInstanceConfig, FakePartialInstanceConfig
 
 # Mark the entire module as tests of type `unit`
 pytestmark = pytest.mark.unit
@@ -39,6 +39,41 @@ def test_jwt_adapter_msft_client(requests_mock: Mocker):
 
     status = SplunkPersistentState({})
     config = FakeInstanceConfig()
+    config.auth_type = AuthType.TokenAuth
+
+    client = SplunkClient(config)
+    client.requests_session.headers.update({'Authorization': "Bearer memorytokenpresent"})
+
+    requests_mock.post("https://login.microsoftonline.com/test-tenant-id/oauth2/v2.0/token",
+                       json={"access_token": fake_jwt, "expires_in": 3600},
+                       status_code=200)
+
+    with patch.dict(os.environ, {"JWT_AUTH": "true", "CLIENT_ID": "test", "CLIENT_SECRET": "test", "SCOPE": "test"}):
+        client.auth_session(status)
+        assert client.requests_session.headers['Authorization'] == f"Bearer {fake_jwt}"
+
+
+def test_jwt_adapter_msft_client_partial_config(requests_mock: Mocker):
+    """
+    Test JWT adapter Microsoft AD JWT client
+    """
+    # Create a valid-looking fake JWT for the mock response
+    exp_time = int(time.time()) + 3600
+    header = {"alg": "RS256", "typ": "JWT"}
+    payload = {"exp": exp_time}
+    encoded_header = base64.urlsafe_b64encode(json.dumps(header).encode()).rstrip(b'=').decode()
+    encoded_payload = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b'=').decode()
+    fake_signature = base64.urlsafe_b64encode(b'fakesignature').rstrip(b'=').decode()
+    fake_jwt = f"{encoded_header}.{encoded_payload}.{fake_signature}"
+
+    os.environ["SPLUNK_MS_JWT_AUTH"] = "true"
+    os.environ["CLIENT_ID"] = "test"
+    os.environ["CLIENT_SECRET"] = "test"
+    os.environ["SCOPE"] = "test"
+    os.environ["TENANT_ID"] = "test-tenant-id"
+
+    status = SplunkPersistentState({})
+    config = FakePartialInstanceConfig()
     config.auth_type = AuthType.TokenAuth
 
     client = SplunkClient(config)


### PR DESCRIPTION
During field QA we discovered that often `keyfile`, `cert` and other options on which the MS JWT client relies on aren't always passed. We therefore decided to relax the requirements since these variables are not really necessary at runtime and we can manage with some sane defaults.