### PR TITLE
STAC-25514: upgrade cryptography to 50.0.0

### DIFF
--- a/stackstate_checks_base/stackstate_checks/base/data/agent_requirements.in
+++ b/stackstate_checks_base/stackstate_checks/base/data/agent_requirements.in
@@ -1,7 +1,7 @@
 boto3==1.42.54; python_version > '3.0'
 cm-client==45.0.4
 ddtrace==4.8.2; python_version > '3.0'
-cryptography==48.0.1; python_version > '3.0'
+cryptography==50.0.0; python_version > '3.0'
 deprecated==1.2.10
 docker==6.1.3
 enum34==1.1.10; python_version < "3.0"


### PR DESCRIPTION
Upgrade the embedded Python cryptography pin from 48.0.1 to 50.0.0 to address CVE-2026-69247, CVE-2026-69249, and CVE-2026-69248.

Jira: https://stackstate.atlassian.net/browse/STAC-25514

Validated with dependency consistency checks, Python 3.13 install/import, and the stackstate_checks_base suite (313 passed, 13 skipped).

After merge, publish the next 7.78.2-* tag for STAC-25515 to consume.